### PR TITLE
Ignore kubeconfig and kube-context when --in-cluster is specified

### DIFF
--- a/lib/src/main/java/com/scalar/admin/k8s/KubernetesClient.java
+++ b/lib/src/main/java/com/scalar/admin/k8s/KubernetesClient.java
@@ -15,12 +15,9 @@ class KubernetesClient {
   private final CoreV1Api coreV1Api;
   private final AppsV1Api appsV1Api;
 
-  KubernetesClient(
-      @Nullable String kubeConfigFilePath,
-      @Nullable String kubeConfigContextName,
-      boolean inCluster) {
+  KubernetesClient(@Nullable String kubeConfigFilePath, @Nullable String kubeConfigContextName) {
     try {
-      if (kubeConfigFilePath != null && !inCluster) {
+      if (kubeConfigFilePath != null) {
         KubeConfig config = KubeConfig.loadKubeConfig(new FileReader(kubeConfigFilePath));
 
         if (kubeConfigContextName == null) {
@@ -33,8 +30,8 @@ class KubernetesClient {
         }
 
         Configuration.setDefaultApiClient(ClientBuilder.kubeconfig(config).build());
-      } else if (kubeConfigContextName != null
-          && !inCluster) { // user doesn't set `--kubeconfig` but set the `--kube-context`
+      } else if (kubeConfigContextName
+          != null) { // user doesn't set `--kubeconfig` but set the `--kube-context`
         if (System.getenv("KUBECONFIG") != null) {
           kubeConfigFilePath = System.getenv("KUBECONFIG");
         } else {

--- a/lib/src/main/java/com/scalar/admin/k8s/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/k8s/Pauser.java
@@ -45,7 +45,12 @@ public class Pauser {
     this.productType = productType;
     this.adminPort = adminPort;
 
-    k8sClient = new KubernetesClient(kubeConfigFilePath, kubeConfigContextName, inCluster);
+    if (inCluster) {
+      kubeConfigFilePath = null;
+      kubeConfigContextName = null;
+    }
+
+    k8sClient = new KubernetesClient(kubeConfigFilePath, kubeConfigContextName);
 
     internalPauser =
         (inCluster) ? new InClusterPauser() : new OutClusterPauser(k8sClient, this.namespace);

--- a/lib/src/test/java/com/scalar/admin/k8s/KubernetesClientTest.java
+++ b/lib/src/test/java/com/scalar/admin/k8s/KubernetesClientTest.java
@@ -81,7 +81,7 @@ public class KubernetesClientTest {
     // Arrange
 
     // Act
-    KubernetesClient client = new KubernetesClient(null, null, false);
+    KubernetesClient client = new KubernetesClient(null, null);
 
     // Assert
     configurationMocked.verify(
@@ -107,7 +107,7 @@ public class KubernetesClientTest {
     when(clientBuilderMocked.build()).thenReturn(apiClientMocked);
 
     // Act
-    KubernetesClient client = new KubernetesClient(configName, null, false);
+    KubernetesClient client = new KubernetesClient(configName, null);
 
     // Assert
     configurationMocked.verify(() -> Configuration.setDefaultApiClient(apiClientMocked), times(1));
@@ -133,7 +133,7 @@ public class KubernetesClientTest {
     when(clientBuilderMocked.build()).thenReturn(apiClientMocked);
 
     // Act
-    KubernetesClient client = new KubernetesClient(configName, contextName, false);
+    KubernetesClient client = new KubernetesClient(configName, contextName);
 
     // Assert
     configurationMocked.verify(() -> Configuration.setDefaultApiClient(apiClientMocked), times(1));
@@ -159,7 +159,7 @@ public class KubernetesClientTest {
     when(clientBuilderMocked.build()).thenReturn(apiClientMocked);
 
     // Act
-    KubernetesClient client = new KubernetesClient(null, contextName, false);
+    KubernetesClient client = new KubernetesClient(null, contextName);
 
     // Assert
     configurationMocked.verify(() -> Configuration.setDefaultApiClient(apiClientMocked), times(1));
@@ -168,29 +168,6 @@ public class KubernetesClientTest {
 
     verify(kubeConfigMocked, never()).getCurrentContext();
     verify(kubeConfigMocked, times(1)).setContext(contextName);
-
-    assertEquals(1, coreV1ApiMocked.constructed().size());
-    assertEquals(1, appsV1ApiMocked.constructed().size());
-    assertEquals(coreV1ApiMocked.constructed().get(0), client.getCoreV1Api());
-    assertEquals(appsV1ApiMocked.constructed().get(0), client.getAppsV1Api());
-  }
-
-  @Test
-  public void
-      constructor_WithConfigAndContextGivenAndInClusterIsTrue_ShouldNotCallLoadKubeConfigAndSetContext() {
-    // Arrange
-    String configName = "file-4";
-    String contextName = "context-4";
-
-    // Act
-    KubernetesClient client = new KubernetesClient(configName, contextName, true);
-
-    // Assert
-    configurationMocked.verify(
-        () -> Configuration.setDefaultApiClient(Config.defaultClient()), times(1));
-    kubeConfigStaticMocked.verify(() -> KubeConfig.loadKubeConfig(any()), never());
-
-    verify(kubeConfigMocked, never()).setContext(anyString());
 
     assertEquals(1, coreV1ApiMocked.constructed().size());
     assertEquals(1, appsV1ApiMocked.constructed().size());


### PR DESCRIPTION
This PR updates the `KubernetesClient` to ignore the `--kubeconfig` and `--kube-context` flag if we specify the `--in-cluster` flag.

When we specify the `--in-cluster` flag, we should use the certificate and token files in the Pod (under /var/run/secrets/kubernetes.io/serviceaccount/ directory) to run the Kubernetes API (to authenticate with kube-apiserver). However, in the current implementation, the `scalar-admin-k8s` uses kubeconfig file according to the `--kubeconfig` flag in spite of we specify the `--in-cluster` flag.

In other words, if we specify the `--in-cluster` flag, we should always use `Configuration.setDefaultApiClient(Config.defaultClient())` to use certificate and token file in the pod even if the `--kubeconfig` and `--kube-context` flags are specified at the same time.

Please take a look!

Note: This PR is based on the `pauser` branch and will be merged in to `pauser` branch.