### PR TITLE
Implement a new option `--time-zone` to output successful message in specific time zone

### DIFF
--- a/cli/src/main/java/com/scalar/admin/k8s/Cli.java
+++ b/cli/src/main/java/com/scalar/admin/k8s/Cli.java
@@ -1,5 +1,6 @@
 package com.scalar.admin.k8s;
 
+import java.time.ZoneId;
 import java.util.concurrent.Callable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +37,15 @@ class Cli implements Callable<Integer> {
   private Integer pauseDuration;
 
   @Option(
+      names = {"--time-zone", "-z"},
+      description =
+          "Specify a time zone ID, e.g., Asia/Tokyo, to output successful paused"
+              + " period. Note the time zone ID is case sensitive. Etc/UTC by default.",
+      converter = ZoneIdConverter.class,
+      defaultValue = "Etc/UTC")
+  private ZoneId zoneId;
+
+  @Option(
       names = {"-h", "--help"},
       usageHelp = true,
       description = "Display the help message.")
@@ -54,8 +64,10 @@ class Cli implements Callable<Integer> {
       PausedDuration duration = pauser.pause(pauseDuration);
 
       System.out.printf(
-          "Paused successfully. Duration: from %s to %s (UTC).\n",
-          duration.getStartTime().toString(), duration.getEndTime().toString());
+          "Paused successfully. Duration: from %s to %s (%s).\n",
+          duration.getStartTime().atZone(zoneId).toLocalDateTime(),
+          duration.getEndTime().atZone(zoneId).toLocalDateTime(),
+          zoneId.toString());
     } catch (PauserException e) {
       logger.error("Failed to pause Scalar products.", e);
       return 1;

--- a/cli/src/main/java/com/scalar/admin/k8s/ZoneIdConverter.java
+++ b/cli/src/main/java/com/scalar/admin/k8s/ZoneIdConverter.java
@@ -1,0 +1,10 @@
+package com.scalar.admin.k8s;
+
+import java.time.ZoneId;
+import picocli.CommandLine.ITypeConverter;
+
+class ZoneIdConverter implements ITypeConverter<ZoneId> {
+  public ZoneId convert(String value) throws Exception {
+    return ZoneId.of(value);
+  }
+}


### PR DESCRIPTION
We add a new option `--time-zone` in the CLI to output successful paused duration in a specific time zone.

NOTE in another PR. the output format will be changed to JSON.