### PR TITLE
Use Gradle short format for the dependency declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,6 @@ subprojects {
     }
 
     dependencies {
-        implementation group: 'org.slf4j', name: 'slf4j-api', version: "${slf4jVersion}"
+        implementation "org.slf4j:slf4j-api:${slf4jVersion}"
     }
 }


### PR DESCRIPTION
This PR revises the Gradle dependency declaration format.
Toshi recommends using the short format.