### PR TITLE
Also handle RuntimeException

### DIFF
--- a/cli/src/main/java/com/scalar/admin/k8s/Cli.java
+++ b/cli/src/main/java/com/scalar/admin/k8s/Cli.java
@@ -68,7 +68,7 @@ class Cli implements Callable<Integer> {
           duration.getStartTime().atZone(zoneId).toLocalDateTime(),
           duration.getEndTime().atZone(zoneId).toLocalDateTime(),
           zoneId.toString());
-    } catch (PauserException e) {
+    } catch (Exception e) {
       logger.error("Failed to pause Scalar products.", e);
       return 1;
     }


### PR DESCRIPTION
This PR fixes the exception handling in the `Cli` class.
It should handle all exceptions, especially the RuntimeException thrown by Kubernetes client library, but not just PauserException.