### PR TITLE
Remove the signing plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Upload the package to Maven Central Repository
+      - name: Upload the package to GitHub Package
         run: |
           ./gradlew publish \
             -PprojVersion="${{ steps.version.outputs.version }}" \

--- a/lib/archive.gradle
+++ b/lib/archive.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 publishing {
     publications {
@@ -45,8 +44,4 @@ publishing {
             }
         }
     }
-}
-
-signing {
-    sign publishing.publications.mavenJava
 }


### PR DESCRIPTION
Sorry, this is another mistake.
I forgot to remove the signing plugin.

Initially, I planned to upload the Java package to the Maven repository.
However, after the discussion with Hiro, we decided to make this a private library because it would be used internally in Scalar with other projects for now. Therefore, I changed the workflow to upload the Java package to GitHub Package.

In the Maven repository, the authentication is signature-based so we need to use the `signing` plugin with
- keyId
- password
- secretKeyRingFile

properties.

In GitHub Package, the authentication is based on username and password so we don't need to sign the package.

Applying the `signing` plugin without giving the properties above causes the error of
```
Execution failed for task ':lib:signMavenJavaPublication'.
> Cannot perform signing task ':lib:signMavenJavaPublication' because it has no configured signatory
```