### PR TITLE
Add README with CLI usage descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,110 @@
+# Scalar Admin k8s
+
+## Usage of the CLI tool
+
+```console
+Usage: scalar-admin-k8s-cli [-h] [-d=<pauseDuration>] [-n=<namespace>]
+                            -r=<helmReleaseName> [-w=<maxPauseWaitTime>]
+                            [-z=<zoneId>]
+Scalar Admin pause tool for the Kubernetes environment
+  -d, --pause-duration=<pauseDuration>
+                             The duration of the pause period by millisecond.
+                               5000 (5 seconds) by default.
+  -h, --help                 Display the help message.
+  -n, --namespace=<namespace>
+                             Namespace that Scalar products you want to pause
+                               are deployed. `default` by default.
+  -r, --release-name=<helmReleaseName>
+                             Helm's release name that you specify when you run
+                               the `helm install <RELEASE_NAME>` command. You
+                               can see the <RELEASE_NAME> by using the `helm
+                               list` command.
+  -w, --max-pause-wait-time=<maxPauseWaitTime>
+                             The max wait time (in milliseconds) until Scalar
+                               products drain outstanding requests before they
+                               pause. If omitting this option, the max wait
+                               time will be the default value defined in the
+                               products. Most Scalar products have the default
+                               value of 30 seconds.
+  -z, --time-zone=<zoneId>   Specify a time zone ID, e.g., Asia/Tokyo, to
+                               output successful paused period. Note the time
+                               zone ID is case sensitive. Etc/UTC by default.
+```
+
+## Run the CLI tool on a Kubernetes environment
+
+The `scalar-admin-k8s` CLI tool executes Kubernetes APIs in its internal processes. To run those Kubernetes APIs, you must run the `scalar-admin-k8s` CLI tool as a pod on the Kubernetes environment and you must:
+
+1. Create three Kubernetes resources (`Role`, `RoleBinding`, and `ServiceAccount`).
+   * Role
+
+     ```yaml
+     apiVersion: rbac.authorization.k8s.io/v1
+     kind: Role
+     metadata:
+       name: scalar-admin-k8s-role
+       namespace: <YOUR_NAMESPACE>
+     rules:
+       - apiGroups: ["", "apps"]
+         resources: ["pods", "deployments", "services"]
+         verbs: ["get", "list"]
+     ```
+
+   * RoleBinding
+
+     ```yaml
+     apiVersion: rbac.authorization.k8s.io/v1
+     kind: RoleBinding
+     metadata:
+       name: scalar-admin-k8s-rolebinding
+       namespace: <YOUR_NAMESPACE>
+     subjects:
+       - kind: ServiceAccount
+         name: scalar-admin-k8s-sa
+     roleRef:
+       kind: Role
+       name: scalar-admin-k8s-role
+       apiGroup: rbac.authorization.k8s.io
+     ```
+
+   * ServiceAccount
+
+     ```yaml
+     apiVersion: v1
+     kind: ServiceAccount
+     metadata:
+       name: scalar-admin-k8s-sa
+       namespace: <YOUR_NAMESPACE>
+     ```
+
+1. Mount the `ServiceAccount` on the `scalar-admin-k8s` pod.
+   * Pod
+
+     ```yaml
+     apiVersion: v1
+     kind: Pod
+     metadata:
+       name: scalar-admin-k8s
+       namespace: <YOUR_NAMESPACE>
+     spec:
+       serviceAccountName: scalar-admin-k8s-sa
+       containers:
+       - name: scalar-admin-k8s
+         image: ghcr.io/scalar-labs/scalar-admin-k8s:1.0.0
+         command:
+           - java
+           - -jar
+           - /app.jar
+           - -r
+           - <HELM_RELEASE_NAME>
+           - -n
+           - <SCALAR_PRODUCT_NAMESPACE>
+           - -d
+           - <PAUSE_DURATION>
+           - -z
+           - <TIMEZONE>
+     ```
+
+## Run the CLI tool on a Kubernetes environment by using Helm Chart
+
+Coming soon.

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ Scalar Admin pause tool for the Kubernetes environment
                                zone ID is case sensitive. Etc/UTC by default.
 ```
 
-## Run the CLI tool on a Kubernetes environment
+## Run the CLI tool in a Kubernetes environment
 
 The `scalar-admin-k8s` CLI tool executes Kubernetes APIs in its internal processes. To run those Kubernetes APIs, you must run the `scalar-admin-k8s` CLI tool as a pod on the Kubernetes environment and you must:
 
-1. Create three Kubernetes resources (`Role`, `RoleBinding`, and `ServiceAccount`).
+1. Create three Kubernetes resources (`Role`, `RoleBinding`, and `ServiceAccount`), replacing the contents in the angle brackets as described:
+
    * Role
 
      ```yaml
@@ -77,7 +78,8 @@ The `scalar-admin-k8s` CLI tool executes Kubernetes APIs in its internal process
        namespace: <YOUR_NAMESPACE>
      ```
 
-1. Mount the `ServiceAccount` on the `scalar-admin-k8s` pod.
+1. Mount the `ServiceAccount` on the `scalar-admin-k8s` pod, replacing the contents in the angle brackets as described:
+
    * Pod
 
      ```yaml
@@ -105,6 +107,6 @@ The `scalar-admin-k8s` CLI tool executes Kubernetes APIs in its internal process
            - <TIMEZONE>
      ```
 
-## Run the CLI tool on a Kubernetes environment by using Helm Chart
+## Run the CLI tool in a Kubernetes environment by using a Helm Chart
 
 Coming soon.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Scalar Admin for Kubernetes
 
+Scalar Admin for Kubernetes is a tool that creates a paused state for Scalar products (for example, ScalarDB and ScalarDL) in a Kubernetes environment. You can use such a paused state to take backups easily and consistently across multiple diverse databases.
+
 ## Usage of the CLI tool
 
 ```console

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Scalar Admin k8s
+# Scalar Admin for Kubernetes
 
 ## Usage of the CLI tool
 
 ```console
-Usage: scalar-admin-k8s-cli [-h] [-d=<pauseDuration>] [-n=<namespace>]
-                            -r=<helmReleaseName> [-w=<maxPauseWaitTime>]
-                            [-z=<zoneId>]
+Usage: scalar-admin-for-kubernetes-cli [-h] [-d=<pauseDuration>]
+                                       [-n=<namespace>] -r=<helmReleaseName>
+                                       [-w=<maxPauseWaitTime>] [-z=<zoneId>]
 Scalar Admin pause tool for the Kubernetes environment
   -d, --pause-duration=<pauseDuration>
                              The duration of the pause period by millisecond.
@@ -33,7 +33,7 @@ Scalar Admin pause tool for the Kubernetes environment
 
 ## Run the CLI tool in a Kubernetes environment
 
-The `scalar-admin-k8s` CLI tool executes Kubernetes APIs in its internal processes. To run those Kubernetes APIs, you must run the `scalar-admin-k8s` CLI tool as a pod on the Kubernetes environment and you must:
+The `scalar-admin-for-kubernetes` CLI tool executes Kubernetes APIs in its internal processes. To run those Kubernetes APIs, you must run the `scalar-admin-for-kubernetes` CLI tool as a pod on the Kubernetes environment and you must:
 
 1. Create three Kubernetes resources (`Role`, `RoleBinding`, and `ServiceAccount`), replacing the contents in the angle brackets as described:
 
@@ -43,7 +43,7 @@ The `scalar-admin-k8s` CLI tool executes Kubernetes APIs in its internal process
      apiVersion: rbac.authorization.k8s.io/v1
      kind: Role
      metadata:
-       name: scalar-admin-k8s-role
+       name: scalar-admin-for-kubernetes-role
        namespace: <YOUR_NAMESPACE>
      rules:
        - apiGroups: ["", "apps"]
@@ -57,14 +57,14 @@ The `scalar-admin-k8s` CLI tool executes Kubernetes APIs in its internal process
      apiVersion: rbac.authorization.k8s.io/v1
      kind: RoleBinding
      metadata:
-       name: scalar-admin-k8s-rolebinding
+       name: scalar-admin-for-kubernetes-rolebinding
        namespace: <YOUR_NAMESPACE>
      subjects:
        - kind: ServiceAccount
-         name: scalar-admin-k8s-sa
+         name: scalar-admin-for-kubernetes-sa
      roleRef:
        kind: Role
-       name: scalar-admin-k8s-role
+       name: scalar-admin-for-kubernetes-role
        apiGroup: rbac.authorization.k8s.io
      ```
 
@@ -74,11 +74,11 @@ The `scalar-admin-k8s` CLI tool executes Kubernetes APIs in its internal process
      apiVersion: v1
      kind: ServiceAccount
      metadata:
-       name: scalar-admin-k8s-sa
+       name: scalar-admin-for-kubernetes-sa
        namespace: <YOUR_NAMESPACE>
      ```
 
-1. Mount the `ServiceAccount` on the `scalar-admin-k8s` pod, replacing the contents in the angle brackets as described:
+1. Mount the `ServiceAccount` on the `scalar-admin-for-kubernetes` pod, replacing the contents in the angle brackets as described:
 
    * Pod
 
@@ -86,13 +86,13 @@ The `scalar-admin-k8s` CLI tool executes Kubernetes APIs in its internal process
      apiVersion: v1
      kind: Pod
      metadata:
-       name: scalar-admin-k8s
+       name: scalar-admin-for-kubernetes
        namespace: <YOUR_NAMESPACE>
      spec:
-       serviceAccountName: scalar-admin-k8s-sa
+       serviceAccountName: scalar-admin-for-kubernetes-sa
        containers:
-       - name: scalar-admin-k8s
-         image: ghcr.io/scalar-labs/scalar-admin-k8s:1.0.0
+       - name: scalar-admin-for-kubernetes
+         image: ghcr.io/scalar-labs/scalar-admin-for-kubernetes:1.0.0
          command:
            - java
            - -jar

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `scalar-admin-for-kubernetes` CLI tool executes Kubernetes APIs in its inter
        namespace: <YOUR_NAMESPACE>
      ```
 
-1. Mount the `ServiceAccount` on the `scalar-admin-for-kubernetes` pod, replacing the contents in the angle brackets as described:
+1. Mount the `ServiceAccount` resource on the `scalar-admin-for-kubernetes` pod, replacing the contents in the angle brackets as described:
 
    * Pod
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Scalar Admin pause tool for the Kubernetes environment
 
 ## Run the CLI tool in a Kubernetes environment
 
-The `scalar-admin-for-kubernetes` CLI tool executes Kubernetes APIs in its internal processes. To run those Kubernetes APIs, you must run the `scalar-admin-for-kubernetes` CLI tool as a pod on the Kubernetes environment and you must:
+The `scalar-admin-for-kubernetes` CLI tool executes Kubernetes APIs in its internal processes. To run those Kubernetes APIs, you must run the `scalar-admin-for-kubernetes` CLI tool as a pod in the Kubernetes environment and do the following:
 
 1. Create three Kubernetes resources (`Role`, `RoleBinding`, and `ServiceAccount`), replacing the contents in the angle brackets as described:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scalar Admin for Kubernetes
 
-Scalar Admin for Kubernetes is a tool that creates a paused state for Scalar products (for example, ScalarDB and ScalarDL) in a Kubernetes environment. You can use such a paused state to take backups easily and consistently across multiple diverse databases.
+Scalar Admin for Kubernetes is a tool that creates a paused state for ScalarDB or ScalarDL in a Kubernetes environment. You can use such a paused state to take backups easily and consistently across multiple diverse databases.
 
 ## Usage of the CLI tool
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Scalar Admin pause tool for the Kubernetes environment
 
 ## Run the CLI tool in a Kubernetes environment
 
-The `scalar-admin-for-kubernetes` CLI tool executes Kubernetes APIs in its internal processes. To run those Kubernetes APIs, you must run the `scalar-admin-for-kubernetes` CLI tool as a pod in the Kubernetes environment and do the following:
+The `scalar-admin-for-kubernetes` CLI tool executes Kubernetes APIs in its internal processes. To run those Kubernetes APIs, you must run the `scalar-admin-for-kubernetes` CLI tool as a pod on the Kubernetes environment by following the steps below:
 
 1. Create three Kubernetes resources (`Role`, `RoleBinding`, and `ServiceAccount`), replacing the contents in the angle brackets as described:
 


### PR DESCRIPTION
## Description

This PR adds a `README`. At this time, it includes descriptions about the CLI tool only.
This is because I need the document of the CLI tool itself to create a new document on the Helm Chart side.
I think we can add descriptions about the Java library if we need it in the future.

## Related issues and/or PRs

N/A

## Changes made

Add `README`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

At the moment, I think we do NOT need to add this `README` to the document side.
This is because we assume that users use Helm Chart to run the Scalar Admin k8s instead of running the CLI tool directly.

In the future, I will create the document `how to run Scalar Admin k8s by using Helm Chart` in the Helm Chart repository and the document `how to perform the backup operation by using Scalar Admin k8s` in the `scalar-kubernetes` repository.
These two documents can help users to run the backup operation. So, I think these documents should be added to the doc site in the future instead of this `README`.

