### PR TITLE
Rename scalar-admin-k8s to scalar-admin-for-kubernetes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Copy Shadow Jar to tester Pod
         run: |
           kubectl wait --for=condition=Ready pod/java8 --timeout 300s
-          kubectl cp cli/build/libs/scalar-admin-k8s-cli-${{ steps.version.outputs.version }}.jar java8:/tmp
+          kubectl cp cli/build/libs/scalar-admin-for-kubernetes-cli-${{ steps.version.outputs.version }}.jar java8:/tmp
 
       - name: Run Shadow Jar
         run: |
-          kubectl exec -it java8 -- java -jar /tmp/scalar-admin-k8s-cli-${{ steps.version.outputs.version }}.jar -r foo
+          kubectl exec -it java8 -- java -jar /tmp/scalar-admin-for-kubernetes-cli-${{ steps.version.outputs.version }}.jar -r foo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,5 +66,5 @@ jobs:
         with:
           context: ./cli
           push: true
-          tags: ghcr.io/scalar-labs/scalar-admin-k8s:${{ steps.version.outputs.version }}
+          tags: ghcr.io/scalar-labs/scalar-admin-for-kubernetes:${{ steps.version.outputs.version }}
           platforms: linux/amd64,linux/arm64/v8

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/scalar-labs/jre8:1.1.14
 
-COPY build/libs/scalar-admin-k8s-cli*.jar /app.jar
+COPY build/libs/scalar-admin-for-kubernetes-cli*.jar /app.jar
 
 RUN groupadd -r --gid 201 scalar && \
     useradd -r --uid 201 -g scalar scalar

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -9,10 +9,10 @@ dependencies {
 }
 
 shadowJar {
-   archiveBaseName.set('scalar-admin-k8s-cli')
+   archiveBaseName.set('scalar-admin-for-kubernetes-cli')
    archiveClassifier.set('')
    manifest {
-        attributes 'Main-Class': 'com.scalar.admin.k8s.Cli'
+        attributes 'Main-Class': 'com.scalar.admin.kubernetes.Cli'
    }
 
    // this is to merge gRPC service files into the shadow jar

--- a/cli/src/main/java/com/scalar/admin/k8s/Cli.java
+++ b/cli/src/main/java/com/scalar/admin/k8s/Cli.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,7 +12,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 @Command(
-    name = "scalar-admin-k8s-cli",
+    name = "scalar-admin-for-kubernetes-cli",
     description = "Scalar Admin pause tool for the Kubernetes environment")
 class Cli implements Callable<Integer> {
 

--- a/cli/src/main/java/com/scalar/admin/k8s/Result.java
+++ b/cli/src/main/java/com/scalar/admin/k8s/Result.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.ZoneId;

--- a/cli/src/main/java/com/scalar/admin/k8s/ZoneIdConverter.java
+++ b/cli/src/main/java/com/scalar/admin/k8s/ZoneIdConverter.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import java.time.ZoneId;
 import picocli.CommandLine.ITypeConverter;

--- a/lib/archive.gradle
+++ b/lib/archive.gradle
@@ -4,12 +4,12 @@ apply plugin: 'signing'
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            artifactId = 'scalar-admin-k8s'
+            artifactId = 'scalar-admin-for-Kubernetes'
             from components.java
             pom {
                 name = 'Scalar Admin for Kubernetes'
                 description = 'This library provides a pause mechanism to the Scalar products in Kubernetes environments to take transactionally consistent backups.'
-                url = 'https://github.com/scalar-labs/scalar-admin-k8s'
+                url = 'https://github.com/scalar-labs/scalar-admin-for-Kubernetes'
                 licenses {
                     license {
                         name = 'Apache License, Version 2.0'
@@ -29,9 +29,9 @@ publishing {
                     }
                 }
                 scm {
-                    connection = 'scm:git:https://github.com/scalar-labs/scalar-admin-k8s.git'
-                    developerConnection = 'scm:git:https://github.com/scalar-labs/scalar-admin-k8s.git'
-                    url = 'https://github.com/scalar-labs/scalar-admin-k8s'
+                    connection = 'scm:git:https://github.com/scalar-labs/scalar-admin-for-kubernetes.git'
+                    developerConnection = 'scm:git:https://github.com/scalar-labs/scalar-admin-for-kubernetes.git'
+                    url = 'https://github.com/scalar-labs/scalar-admin-for-kubernetes'
                 }
             }
         }

--- a/lib/src/main/java/com/scalar/admin/k8s/PausedDuration.java
+++ b/lib/src/main/java/com/scalar/admin/k8s/PausedDuration.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import java.time.Instant;
 import javax.annotation.concurrent.Immutable;

--- a/lib/src/main/java/com/scalar/admin/k8s/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/k8s/Pauser.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scalar.admin.RequestCoordinator;

--- a/lib/src/main/java/com/scalar/admin/k8s/PauserException.java
+++ b/lib/src/main/java/com/scalar/admin/k8s/PauserException.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 public class PauserException extends Exception {
   public PauserException(String message) {

--- a/lib/src/main/java/com/scalar/admin/k8s/Product.java
+++ b/lib/src/main/java/com/scalar/admin/k8s/Product.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 enum Product {
   SCALARDB_SERVER("scalardb", "scalardb"),

--- a/lib/src/main/java/com/scalar/admin/k8s/TargetSelector.java
+++ b/lib/src/main/java/com/scalar/admin/k8s/TargetSelector.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.AppsV1Api;

--- a/lib/src/main/java/com/scalar/admin/k8s/TargetSnapshot.java
+++ b/lib/src/main/java/com/scalar/admin/k8s/TargetSnapshot.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import com.google.common.collect.ImmutableList;
 import io.kubernetes.client.openapi.models.V1Deployment;

--- a/lib/src/main/java/com/scalar/admin/k8s/TargetStatus.java
+++ b/lib/src/main/java/com/scalar/admin/k8s/TargetStatus.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;

--- a/lib/src/test/java/com/scalar/admin/k8s/ProductTest.java
+++ b/lib/src/test/java/com/scalar/admin/k8s/ProductTest.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 

--- a/lib/src/test/java/com/scalar/admin/k8s/TargetSelectorTest.java
+++ b/lib/src/test/java/com/scalar/admin/k8s/TargetSelectorTest.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/lib/src/test/java/com/scalar/admin/k8s/TargetSnapshotTest.java
+++ b/lib/src/test/java/com/scalar/admin/k8s/TargetSnapshotTest.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/lib/src/test/java/com/scalar/admin/k8s/TargetStatusTest.java
+++ b/lib/src/test/java/com/scalar/admin/k8s/TargetStatusTest.java
@@ -1,4 +1,4 @@
-package com.scalar.admin.k8s;
+package com.scalar.admin.kubernetes;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
-rootProject.name = 'scalar-admin-k8s'
+rootProject.name = 'scalar-admin-for-kubernetes'
 include 'lib'
 include 'cli'


### PR DESCRIPTION
## Description

This PR renames `scalar-admin-k8s` to `scalar-admin-for-kubernetes`.

The original discussion is https://github.com/scalar-labs/scalar-admin-for-kubernetes/pull/20#pullrequestreview-1769732549 and the meeting (12/21) notes is: https://scalar-labs.atlassian.net/wiki/spaces/SD/pages/1822261303/2023-12-21+Meeting+notes+Scalar+Admin+for+Kubernetes

## Related issues and/or PRs

https://github.com/scalar-labs/scalar-admin-for-kubernetes/pull/20

## Changes made

- renamed CLI to `scalar-admin-for-kubernetes-cli-{version}.jar`
- renamed Docker image to `ghcr.io/scalar-labs/scalar-admin-for-kubernetes:{version}`
- renamed Java package to `com.scalar.admin.kubernetes`

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.