### PR TITLE
Typo

### DIFF
--- a/lib/archive.gradle
+++ b/lib/archive.gradle
@@ -4,12 +4,12 @@ apply plugin: 'signing'
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            artifactId = 'scalar-admin-for-Kubernetes'
+            artifactId = 'scalar-admin-for-kubernetes'
             from components.java
             pom {
                 name = 'Scalar Admin for Kubernetes'
                 description = 'This library provides a pause mechanism to the Scalar products in Kubernetes environments to take transactionally consistent backups.'
-                url = 'https://github.com/scalar-labs/scalar-admin-for-Kubernetes'
+                url = 'https://github.com/scalar-labs/scalar-admin-for-kubernetes'
                 licenses {
                     license {
                         name = 'Apache License, Version 2.0'


### PR DESCRIPTION
## Description

This PR fixes a typo in the `archive.gradle`. I made a mistake when we renamed `scalar-admin-k8s` to `scalar-admin-for-kubernetes`.

## Related issues and/or PRs

#21 

## Changes made

- revised `archive.gradle`

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.