### PR TITLE
Use Temurin's base image

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,6 @@
 FROM eclipse-temurin:8-jre
-RUN apt-get upgrade -y
+RUN apt-get update && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY build/libs/scalar-admin-for-kubernetes-cli*.jar /app.jar
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/scalar-labs/jre8:1.1.14
+FROM eclipse-temurin:8-jre
+RUN apt-get upgrade -y
 
 COPY build/libs/scalar-admin-for-kubernetes-cli*.jar /app.jar
 


### PR DESCRIPTION
## Description

This PR changes the Dockerfile to use Temurin's Java 8 JRE image as the base image since OpenJDK stopped providing official Docker images and we don't want to maintain in-house Java base image anymore.

## Related issues and/or PRs

N/A

## Changes made
- revised Dockerfile

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.