### PR TITLE
Add a workflow to remove untagged images regularly

### DIFF
--- a/.github/workflows/remove-untagged-images.yaml
+++ b/.github/workflows/remove-untagged-images.yaml
@@ -1,0 +1,22 @@
+# When we push a new SNAPSHOT image, the old SNAPSHOT image remains as an untagged
+# image in GitHub Packages. We remove those untagged images by using this workflow.
+
+name: Remove untagged images
+
+on:
+  schedule:
+    # UTC
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  remove-untagged-container-images:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: scalar-admin-for-kubernetes
+        uses: camargo/delete-untagged-action@v1
+        with:
+          github-token: ${{ secrets.CR_PAT }}
+          package-name: scalar-admin-for-kubernetes


### PR DESCRIPTION
## Description

This PR adds a new workflow to remove untagged images regularly (at 03:00 every Monday, UTC)

## Related issues and/or PRs

N/A

## Changes made

- added a new GitHub Actions workflow

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.