### PR TITLE
Update pauser to handle exception and run unpause as long as possible

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:${junitVersion}"))
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.mockito:mockito-inline:${mockitoVersion}"
 }
 
 test {

--- a/lib/src/main/java/com/scalar/admin/kubernetes/GetTargetAfterPauseFailedException.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/GetTargetAfterPauseFailedException.java
@@ -1,0 +1,11 @@
+package com.scalar.admin.kubernetes;
+
+public class GetTargetAfterPauseFailedException extends PauserException {
+  public GetTargetAfterPauseFailedException(String message) {
+    super(message);
+  }
+
+  public GetTargetAfterPauseFailedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/lib/src/main/java/com/scalar/admin/kubernetes/PauseFailedException.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/PauseFailedException.java
@@ -1,6 +1,6 @@
 package com.scalar.admin.kubernetes;
 
-public class PauseFailedException extends Exception {
+public class PauseFailedException extends PauserException {
   public PauseFailedException(String message) {
     super(message);
   }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/PauseFailedException.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/PauseFailedException.java
@@ -1,0 +1,11 @@
+package com.scalar.admin.kubernetes;
+
+public class PauseFailedException extends Exception {
+  public PauseFailedException(String message) {
+    super(message);
+  }
+
+  public PauseFailedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -247,7 +247,8 @@ public class Pauser {
       pauserException = unpauseFailedException;
     }
 
-    // Treat the pause failure as the second priority because the issue might be caused by a configuration mistake.
+    // Treat the pause failure as the second priority because the issue might be caused by a
+    // configuration mistake.
     if (pauseFailedException != null) {
       if (pauserException == null) {
         pauserException = pauseFailedException;
@@ -256,8 +257,8 @@ public class Pauser {
       }
     }
 
-    // Treat the getting target failure as the third priority because this issue might be caused by a temporary glitch, for
-    // example, network failures.
+    // Treat the getting target failure as the third priority because this issue might be caused by
+    // a temporary glitch, for example, network failures.
     if (getTargetAfterPauseFailedException != null) {
       if (pauserException == null) {
         pauserException = getTargetAfterPauseFailedException;
@@ -266,8 +267,9 @@ public class Pauser {
       }
     }
 
-    // Treat the status checking failure as third priority because this issue might be caused by a temporary glitch,
-    // for example, targetAfterPause is null.
+    // Treat the status checking failure as the third priority because this issue might be caused by
+    // a temporary glitch, for example, getting target information by using the Kubernetes API fails
+    // after the pause operation.
     if (statusCheckFailedException != null) {
       if (pauserException == null) {
         pauserException = statusCheckFailedException;
@@ -276,8 +278,8 @@ public class Pauser {
       }
     }
 
-    // Treat the status unmatched issue as third priority because this issue might be caused by temporary
-    // glitch, for example, pod restarts.
+    // Treat the status unmatched issue as the third priority because this issue might be caused by
+    // temporary glitch, for example, pod restarts.
     if (statusUnmatchedException != null) {
       if (pauserException == null) {
         pauserException = statusUnmatchedException;

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -130,7 +130,7 @@ public class Pauser {
     String statusDifferentErrorMessage =
         "The target pods were updated during the pause duration. You cannot use the backup that"
             + " was taken during this pause duration. ";
-    String unpauseFailedButBackupOkErrorMessage =
+    String unpauseFailedButPauseOkErrorMessage =
         String.format(
             "Note that the pause operations for taking backup succeeded. You can use a backup that"
                 + " was taken during this pause duration: Start Time = %s, End Time = %s. ",
@@ -166,14 +166,14 @@ public class Pauser {
 
     // If both the pause operation and status check succeeded, you can use the backup that was taken
     // during the pause duration.
-    boolean backupOk = (pauseFailedException == null) && compareTargetSuccessful;
+    boolean isPauseOk = (pauseFailedException == null) && compareTargetSuccessful;
 
     // Create an error message if any of the operations failed.
     StringBuilder errorMessageBuilder = new StringBuilder();
     if (unpauseFailedException != null) {
       errorMessageBuilder.append(unpauseErrorMessage);
-      if (backupOk) {
-        errorMessageBuilder.append(unpauseFailedButBackupOkErrorMessage);
+      if (isPauseOk) {
+        errorMessageBuilder.append(unpauseFailedButPauseOkErrorMessage);
       }
     }
     if (pauseFailedException != null) {

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -110,6 +110,10 @@ public class Pauser {
       throw new PauserException("Failed to initialize the request coordinator.", e);
     }
 
+    // From here, we cannot throw exceptions right after they occur because we need to take care of
+    // the unpause operation failure. We will throw the exception after the unpause operation or at
+    // the end of this method.
+
     // Run a pause operation.
     PausedDuration pausedDuration = null;
     PauseFailedException pauseFailedException = null;
@@ -158,6 +162,12 @@ public class Pauser {
     // Create an error message if any of the operations failed.
     String errorMessage =
         createErrorMessage(unpauseFailedException, pauseFailedException, isTargetStatusEqual);
+
+    // We use the exceptions as conditions instead of using boolean flags like `isPauseOk`, etc. If
+    // we use boolean flags, it might cause a bit large number of combinations. For example, if we
+    // have three flags, they generate 2^3 = 8 combinations. It also might make the nested if
+    // statement or a lot of branches of the switch statement. That's why we don't use status flags
+    // for now.
 
     // Return the final result based on each process.
     if (unpauseFailedException != null) { // Unpause Failed.

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -93,7 +93,7 @@ public class Pauser {
       throw new PauserException("Failed to initialize the request coordinator.", e);
     }
 
-    // Run pause operation.
+    // Run a pause operation.
     PauseFailedException pauseFailedException = null;
     try {
       pauseInternal(requestCoordinator, pauseDuration, maxPauseWaitTime);
@@ -101,7 +101,7 @@ public class Pauser {
       pauseFailedException = new PauseFailedException("Pause operation failed.", e);
     }
 
-    // Run unpause operation.
+    // Run an unpause operation.
     UnpauseFailedException unpauseFailedException = null;
     try {
       unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
@@ -168,7 +168,7 @@ public class Pauser {
     // during the pause duration.
     boolean backupOk = (pauseFailedException == null) && compareTargetSuccessful;
 
-    // Create error message if any of the operations failed.
+    // Create an error message if any of the operations failed.
     StringBuilder errorMessageBuilder = new StringBuilder();
     if (unpauseFailedException != null) {
       errorMessageBuilder.append(unpauseErrorMessage);

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -78,12 +78,7 @@ public class Pauser {
           "pauseDuration is required to be greater than 0 millisecond.");
     }
 
-    TargetSnapshot target;
-    try {
-      target = targetSelector.select();
-    } catch (Exception e) {
-      throw new PauserException("Failed to find the target pods to pause.", e);
-    }
+    TargetSnapshot target = getTarget();
 
     RequestCoordinator coordinator;
     try {
@@ -157,6 +152,14 @@ public class Pauser {
               e);
         }
       }
+    }
+  }
+
+  TargetSnapshot getTarget() throws PauserException {
+    try {
+      return targetSelector.select();
+    } catch (Exception e) {
+      throw new PauserException("Failed to find the target pods to pause.", e);
     }
   }
 

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -153,10 +153,12 @@ public class Pauser {
     // Check if pods and deployment information are the same between before pause and after pause.
     StatusCheckFailedException statusCheckFailedException = null;
     StatusUnmatchedException statusUnmatchedException = null;
-    try {
-      statusUnmatchedException = targetStatusEquals(targetBeforePause, targetAfterPause);
-    } catch (Exception e) {
-      statusCheckFailedException = new StatusCheckFailedException(STATUS_CHECK_ERROR_MESSAGE, e);
+    if (targetAfterPause != null) {
+      try {
+        statusUnmatchedException = targetStatusEquals(targetBeforePause, targetAfterPause);
+      } catch (Exception e) {
+        statusCheckFailedException = new StatusCheckFailedException(STATUS_CHECK_ERROR_MESSAGE, e);
+      }
     }
 
     // We use the exceptions as conditions instead of using boolean flags like `isPauseOk`, etc. If
@@ -222,9 +224,8 @@ public class Pauser {
 
   @VisibleForTesting
   @Nullable
-  StatusUnmatchedException targetStatusEquals(
-      TargetSnapshot before, @Nullable TargetSnapshot after) {
-    if (after != null && before.getStatus().equals(after.getStatus())) {
+  StatusUnmatchedException targetStatusEquals(TargetSnapshot before, TargetSnapshot after) {
+    if (before.getStatus().equals(after.getStatus())) {
       return null;
     } else {
       return new StatusUnmatchedException(STATUS_UNMATCHED_ERROR_MESSAGE);

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -135,11 +135,10 @@ public class Pauser {
 
     // Get pods and deployment information after pause.
     TargetSnapshot targetAfterPause;
-    PauserException pauserException;
     try {
       targetAfterPause = getTarget();
     } catch (Exception e) {
-      pauserException = new PauserException(getTargetAfterPauseErrorMessage, e);
+      PauserException pauserException = new PauserException(getTargetAfterPauseErrorMessage, e);
       if (unpauseFailedException == null) {
         throw pauserException;
       } else {
@@ -149,11 +148,11 @@ public class Pauser {
 
     // Check if pods and deployment information are the same between before pause and after pause.
     boolean isTargetStatusEqual;
-    StatusCheckFailedException statusCheckFailedException;
     try {
       isTargetStatusEqual = targetStatusEquals(targetBeforePause, targetAfterPause);
     } catch (Exception e) {
-      statusCheckFailedException = new StatusCheckFailedException(statusCheckErrorMessage, e);
+      StatusCheckFailedException statusCheckFailedException =
+          new StatusCheckFailedException(statusCheckErrorMessage, e);
       if (unpauseFailedException == null) {
         throw statusCheckFailedException;
       } else {

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -151,10 +151,10 @@ public class Pauser {
     }
 
     // Check if pods and deployment information are the same between before pause and after pause.
-    boolean compareTargetSuccessful;
+    boolean isTargetStatusEqual;
     StatusCheckFailedException statusCheckFailedException;
     try {
-      compareTargetSuccessful = compareTargetStatus(targetBeforePause, targetAfterPause);
+      isTargetStatusEqual = targetStatusEquals(targetBeforePause, targetAfterPause);
     } catch (Exception e) {
       statusCheckFailedException = new StatusCheckFailedException(statusCheckErrorMessage, e);
       if (unpauseFailedException == null) {
@@ -166,7 +166,7 @@ public class Pauser {
 
     // If both the pause operation and status check succeeded, you can use the backup that was taken
     // during the pause duration.
-    boolean isPauseOk = (pauseFailedException == null) && compareTargetSuccessful;
+    boolean isPauseOk = (pauseFailedException == null) && isTargetStatusEqual;
 
     // Create an error message if any of the operations failed.
     StringBuilder errorMessageBuilder = new StringBuilder();
@@ -179,7 +179,7 @@ public class Pauser {
     if (pauseFailedException != null) {
       errorMessageBuilder.append(pauseErrorMessage);
     }
-    if (!compareTargetSuccessful) {
+    if (!isTargetStatusEqual) {
       errorMessageBuilder.append(statusDifferentErrorMessage);
     }
     String errorMessage = errorMessageBuilder.toString();
@@ -192,7 +192,7 @@ public class Pauser {
         != null) { // Pause Failed is second priority because pause issue might be caused by
       // configuration error.
       throw new PauseFailedException(errorMessage, pauseFailedException);
-    } else if (!compareTargetSuccessful) { // Status check failed is third priority because this
+    } else if (!isTargetStatusEqual) { // Status check failed is third priority because this
       // issue might be caused by temporary issue, for example, pod restarts.
       throw new PauseFailedException(errorMessage);
     } else { // All operations succeeded.
@@ -239,7 +239,7 @@ public class Pauser {
   }
 
   @VisibleForTesting
-  boolean compareTargetStatus(TargetSnapshot before, TargetSnapshot after) {
+  boolean targetStatusEquals(TargetSnapshot before, TargetSnapshot after) {
     return before.getStatus().equals(after.getStatus());
   }
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -242,12 +242,12 @@ public class Pauser {
       @Nullable StatusUnmatchedException statusUnmatchedException) {
     PauserException pauserException = null;
 
-    // Unpause issue is the most critical because it might cause system down.
+    // Treat the unpause failure as most critical because it might cause system unavailability.
     if (unpauseFailedException != null) {
       pauserException = unpauseFailedException;
     }
 
-    // Pause Failed is second priority because pause issue might be caused by configuration error.
+    // Treat the pause failure as the second priority because the issue might be caused by a configuration mistake.
     if (pauseFailedException != null) {
       if (pauserException == null) {
         pauserException = pauseFailedException;
@@ -256,8 +256,8 @@ public class Pauser {
       }
     }
 
-    // Get target issue is third priority because this issue might be caused by temporary issue, for
-    // example, network issues.
+    // Treat the getting target failure as the third priority because this issue might be caused by a temporary glitch, for
+    // example, network failures.
     if (getTargetAfterPauseFailedException != null) {
       if (pauserException == null) {
         pauserException = getTargetAfterPauseFailedException;
@@ -266,7 +266,7 @@ public class Pauser {
       }
     }
 
-    // Status check issue is third priority because this issue might be caused by temporary issue,
+    // Treat the status checking failure as third priority because this issue might be caused by a temporary glitch,
     // for example, targetAfterPause is null.
     if (statusCheckFailedException != null) {
       if (pauserException == null) {
@@ -276,8 +276,8 @@ public class Pauser {
       }
     }
 
-    // Status unmatched issue is third priority because this issue might be caused by temporary
-    // issue, for example, pod restarts.
+    // Treat the status unmatched issue as third priority because this issue might be caused by temporary
+    // glitch, for example, pod restarts.
     if (statusUnmatchedException != null) {
       if (pauserException == null) {
         pauserException = statusUnmatchedException;

--- a/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java
@@ -149,10 +149,10 @@ public class Pauser {
         return;
       } catch (Exception e) {
         if (++retryCounter >= maxRetryCount) {
-          // If someone uses this library directly instead of using our CLI, users should handle the
-          // exception properly. However, this case is a very critical issue. Therefore, we output
-          // the error message here despite whether the exception is handled or not on the caller
-          // side.
+          // Users who directly utilize this library, bypassing our CLI, are responsible for proper
+          // exception handling. However, this scenario represents a critical issue. Consequently,
+          // we output the error message here regardless of whether the calling code handles the
+          // exception.
           logger.error(
               "Failed to unpause Scalar product. They are still in paused. You must restart related"
                   + " pods by using the `kubectl rollout restart deployment {}`"
@@ -176,6 +176,7 @@ public class Pauser {
     return targetSelector.select();
   }
 
+  @VisibleForTesting
   RequestCoordinator getRequestCoordinator(TargetSnapshot target) {
     return new RequestCoordinator(
         target.getPods().stream()

--- a/lib/src/main/java/com/scalar/admin/kubernetes/StatusCheckFailedException.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/StatusCheckFailedException.java
@@ -1,0 +1,11 @@
+package com.scalar.admin.kubernetes;
+
+public class StatusCheckFailedException extends Exception {
+  public StatusCheckFailedException(String message) {
+    super(message);
+  }
+
+  public StatusCheckFailedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/lib/src/main/java/com/scalar/admin/kubernetes/StatusCheckFailedException.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/StatusCheckFailedException.java
@@ -1,6 +1,6 @@
 package com.scalar.admin.kubernetes;
 
-public class StatusCheckFailedException extends Exception {
+public class StatusCheckFailedException extends PauserException {
   public StatusCheckFailedException(String message) {
     super(message);
   }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/StatusUnmatchedException.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/StatusUnmatchedException.java
@@ -1,0 +1,11 @@
+package com.scalar.admin.kubernetes;
+
+public class StatusUnmatchedException extends PauserException {
+  public StatusUnmatchedException(String message) {
+    super(message);
+  }
+
+  public StatusUnmatchedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/lib/src/main/java/com/scalar/admin/kubernetes/UnpauseFailedException.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/UnpauseFailedException.java
@@ -1,6 +1,6 @@
 package com.scalar.admin.kubernetes;
 
-public class UnpauseFailedException extends Exception {
+public class UnpauseFailedException extends PauserException {
   public UnpauseFailedException(String message) {
     super(message);
   }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/UnpauseFailedException.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/UnpauseFailedException.java
@@ -1,0 +1,11 @@
+package com.scalar.admin.kubernetes;
+
+public class UnpauseFailedException extends Exception {
+  public UnpauseFailedException(String message) {
+    super(message);
+  }
+
+  public UnpauseFailedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
@@ -25,8 +25,8 @@ class PauserTest {
 
   private MockedStatic<Config> mockedConfig;
   private RequestCoordinator requestCoordinator;
-  private TargetSnapshot targetSnapshot;
-  private TargetSelector targetSelector;
+  private TargetSnapshot targetBeforePause;
+  private TargetSnapshot targetAfterPause;
   private V1Deployment deployment;
   private V1ObjectMeta objectMeta;
   private final String dummyObjectName = "dummyObjectName";
@@ -36,15 +36,15 @@ class PauserTest {
     mockedConfig = mockStatic(Config.class);
     mockedConfig.when(() -> Config.defaultClient()).thenReturn(null);
     requestCoordinator = mock(RequestCoordinator.class);
-    targetSnapshot = mock(TargetSnapshot.class);
-    targetSelector = mock(TargetSelector.class);
     deployment = mock(V1Deployment.class);
     objectMeta = mock(V1ObjectMeta.class);
+    targetBeforePause = mock(TargetSnapshot.class);
+    targetAfterPause = mock(TargetSnapshot.class);
 
-    when(targetSnapshot.getDeployment()).thenReturn(deployment);
-    when(deployment.getMetadata()).thenReturn(objectMeta);
-    when(objectMeta.getName()).thenReturn(dummyObjectName);
-    when(targetSelector.select()).thenReturn(targetSnapshot);
+    doReturn(deployment).when(targetBeforePause).getDeployment();
+    doReturn(deployment).when(targetAfterPause).getDeployment();
+    doReturn(objectMeta).when(deployment).getMetadata();
+    doReturn(dummyObjectName).when(objectMeta).getName();
   }
 
   @AfterEach
@@ -53,9 +53,9 @@ class PauserTest {
   }
 
   @Nested
-  class ConstructorPauser {
+  class Constructor {
     @Test
-    void WithCorrectArgsReturnPauser() throws PauserException, IOException {
+    void constructor_WithCorrectArgs_ReturnPauser() throws PauserException, IOException {
       // Arrange
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
@@ -65,7 +65,7 @@ class PauserTest {
     }
 
     @Test
-    void WithNullNamespaceShouldThrowException() {
+    void constructor_WithNullNamespace_ShouldThrowIllegalArgumentException() {
       // Arrange
       String namespace = null;
       String helmReleaseName = "dummyRelease";
@@ -78,7 +78,7 @@ class PauserTest {
     }
 
     @Test
-    void WithNullHelmReleaseNameShouldThrowException() {
+    void constructor_WithNullHelmReleaseName_ShouldThrowIllegalArgumentException() {
       // Arrange
       String namespace = "dummyNs";
       String helmReleaseName = null;
@@ -91,7 +91,7 @@ class PauserTest {
     }
 
     @Test
-    void WhenSetDefaultApiClientThrowIOExceptionShouldThrowException() {
+    void constructor_WhenSetDefaultApiClientThrowIOException_ShouldThrowPauserException() {
       // Arrange
       mockedConfig.when(() -> Config.defaultClient()).thenThrow(IOException.class);
       String namespace = "dummyNs";
@@ -105,292 +105,10 @@ class PauserTest {
   }
 
   @Nested
-  class MethodPause {
-    @Test
-    void LessThanOnePauseDurationShouldThrowException() throws PauserException {
-      // Arrange
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 0;
-      Pauser pauser = new Pauser(namespace, helmReleaseName);
-
-      // Act & Assert
-      IllegalArgumentException thrown =
-          assertThrows(IllegalArgumentException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals(
-          "pauseDuration is required to be greater than 0 millisecond.", thrown.getMessage());
-    }
+  class Pause {
 
     @Test
-    void WhenFirstTargetSelectorThrowExceptionShouldThrowException() throws PauserException {
-      // Arrange
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 1;
-      Pauser pauser = new Pauser(namespace, helmReleaseName);
-      when(targetSelector.select()).thenThrow(RuntimeException.class);
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals("Failed to find the target pods to pause.", thrown.getMessage());
-    }
-
-    @Test
-    void WhenGetRequestCoordinatorThrowExceptionShouldThrowException() throws PauserException {
-      // Arrange
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 1;
-      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
-      doReturn(targetSnapshot).when(pauser).getTarget();
-      doThrow(RuntimeException.class).when(pauser).getRequestCoordinator(targetSnapshot);
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals("Failed to initialize the coordinator.", thrown.getMessage());
-    }
-
-    @Test
-    void WhenCoordinatorPauseThrowExceptionShouldRunUnpause() throws PauserException {
-      // Arrange
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 1;
-      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
-      doReturn(targetSnapshot).when(pauser).getTarget();
-      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
-      doThrow(RuntimeException.class).when(requestCoordinator).pause(true, null);
-      doNothing().when(requestCoordinator).unpause();
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals(
-          "The pause operation failed for some reason. However, the unpause operation succeeded"
-              + " afterward. Currently, the scalar products are running with the unpause status."
-              + " You should retry the pause operation to ensure proper backup.",
-          thrown.getMessage());
-      verify(pauser, times(1))
-          .unpauseWithRetry(
-              any(RequestCoordinator.class),
-              eq(MAX_UNPAUSE_RETRY_COUNT),
-              any(TargetSnapshot.class));
-    }
-
-    @Test
-    void WhenInstantNowThrowExceptionShouldRunUnpause() throws PauserException {
-      // Arrange
-      MockedStatic<Instant> mockedTime = mockStatic(Instant.class);
-      mockedTime.when(() -> Instant.now()).thenThrow(RuntimeException.class);
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 1;
-      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
-      doReturn(targetSnapshot).when(pauser).getTarget();
-      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
-      doNothing().when(requestCoordinator).pause(true, null);
-      doNothing().when(requestCoordinator).unpause();
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals(
-          "The pause operation failed for some reason. However, the unpause operation succeeded"
-              + " afterward. Currently, the scalar products are running with the unpause status."
-              + " You should retry the pause operation to ensure proper backup.",
-          thrown.getMessage());
-      verify(pauser, times(1))
-          .unpauseWithRetry(
-              any(RequestCoordinator.class),
-              eq(MAX_UNPAUSE_RETRY_COUNT),
-              any(TargetSnapshot.class));
-
-      mockedTime.close();
-    }
-
-    @Test
-    void WhenSleepThrowExceptionShouldRunUnpause() throws PauserException {
-      // Arrange
-      int pauseDuration = 1;
-      MockedStatic<Uninterruptibles> mockedSleep = mockStatic(Uninterruptibles.class);
-      mockedSleep
-          .when(() -> Uninterruptibles.sleepUninterruptibly(pauseDuration, TimeUnit.MILLISECONDS))
-          .thenThrow(RuntimeException.class);
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
-      doReturn(targetSnapshot).when(pauser).getTarget();
-      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
-      doNothing().when(requestCoordinator).pause(true, null);
-      doNothing().when(requestCoordinator).unpause();
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals(
-          "The pause operation failed for some reason. However, the unpause operation succeeded"
-              + " afterward. Currently, the scalar products are running with the unpause status."
-              + " You should retry the pause operation to ensure proper backup.",
-          thrown.getMessage());
-      verify(pauser, times(1))
-          .unpauseWithRetry(
-              any(RequestCoordinator.class),
-              eq(MAX_UNPAUSE_RETRY_COUNT),
-              any(TargetSnapshot.class));
-
-      mockedSleep.close();
-    }
-
-    @Test
-    void WhenUnpauseThrowExceptionShouldRunUnpauseAgain() throws PauserException {
-      // Arrange
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 1;
-      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
-      doReturn(targetSnapshot).when(pauser).getTarget();
-      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
-      doNothing().when(requestCoordinator).pause(true, null);
-      doThrow(RuntimeException.class)
-          .doNothing()
-          .when(pauser)
-          .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT, targetSnapshot);
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals(
-          "The pause operation failed for some reason. However, the unpause operation succeeded"
-              + " afterward. Currently, the scalar products are running with the unpause status."
-              + " You should retry the pause operation to ensure proper backup.",
-          thrown.getMessage());
-      verify(pauser, times(2))
-          .unpauseWithRetry(
-              any(RequestCoordinator.class),
-              eq(MAX_UNPAUSE_RETRY_COUNT),
-              any(TargetSnapshot.class));
-    }
-
-    @Test
-    void WhenUnpauseThrowPauserExceptionTwiceShouldRunUnpauseAgain() throws PauserException {
-      // Arrange
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 1;
-      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
-      doReturn(targetSnapshot).when(pauser).getTarget();
-      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
-      doNothing().when(requestCoordinator).pause(true, null);
-      doThrow(PauserException.class)
-          .doThrow(PauserException.class)
-          .when(pauser)
-          .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT, targetSnapshot);
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals("unpauseWithRetry() method failed twice.", thrown.getMessage());
-      verify(pauser, times(2))
-          .unpauseWithRetry(
-              any(RequestCoordinator.class),
-              eq(MAX_UNPAUSE_RETRY_COUNT),
-              any(TargetSnapshot.class));
-    }
-
-    @Test
-    void WhenUnpauseThrowUnexpectedExceptionTwiceShouldRunUnpauseAgain() throws PauserException {
-      // Arrange
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 1;
-      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
-      doReturn(targetSnapshot).when(pauser).getTarget();
-      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
-      doNothing().when(requestCoordinator).pause(true, null);
-      doThrow(RuntimeException.class)
-          .doThrow(RuntimeException.class)
-          .when(pauser)
-          .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT, targetSnapshot);
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals(
-          "unpauseWithRetry() method failed twice due to unexpected exception.",
-          thrown.getMessage());
-      verify(pauser, times(2))
-          .unpauseWithRetry(
-              any(RequestCoordinator.class),
-              eq(MAX_UNPAUSE_RETRY_COUNT),
-              any(TargetSnapshot.class));
-    }
-
-    @Test
-    void WhenSecondTargetSelectorThrowExceptionShouldThrowException() throws PauserException {
-      // Arrange
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 1;
-      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
-      doReturn(targetSnapshot).doThrow(RuntimeException.class).when(pauser).getTarget();
-      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
-      doNothing().when(requestCoordinator).pause(true, null);
-      doNothing().when(requestCoordinator).unpause();
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals(
-          "Failed to find the target pods to examine if the targets pods were updated during"
-              + " paused.",
-          thrown.getMessage());
-    }
-
-    @Test
-    void WhenTargetPodStatusChangedShouldThrowException() throws PauserException {
-      // Arrange
-      TargetSnapshot targetBeforePause = mock(TargetSnapshot.class);
-      TargetSnapshot targetAfterPause = mock(TargetSnapshot.class);
-      Map<String, Integer> podRestartCounts =
-          new HashMap<String, Integer>() {
-            {
-              put("dummyKey", 1);
-            }
-          };
-      Map<String, String> podResourceVersions =
-          new HashMap<String, String>() {
-            {
-              put("dummyKey", "dummyValue");
-            }
-          };
-      TargetStatus beforeTargetStatus =
-          new TargetStatus(podRestartCounts, podResourceVersions, "beforeDifferentValue");
-      TargetStatus afterTargetStatus =
-          new TargetStatus(podRestartCounts, podResourceVersions, "afterDifferentValue");
-      doReturn(beforeTargetStatus).when(targetBeforePause).getStatus();
-      doReturn(afterTargetStatus).when(targetAfterPause).getStatus();
-      String namespace = "dummyNs";
-      String helmReleaseName = "dummyRelease";
-      int pauseDuration = 1;
-      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
-      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
-      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
-      doNothing().when(requestCoordinator).pause(true, null);
-      doNothing().when(requestCoordinator).unpause();
-
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
-      assertEquals(
-          "The target pods were updated during paused. Please retry.", thrown.getMessage());
-    }
-
-    @Test
-    void WhenPauseSucceededReturnPausedDuration() throws PauserException {
-      TargetSnapshot targetBeforePause = mock(TargetSnapshot.class);
-      TargetSnapshot targetAfterPause = mock(TargetSnapshot.class);
+    void pause_WhenPauseSucceeded_ReturnPausedDuration() throws PauserException {
       Map<String, Integer> podRestartCounts =
           new HashMap<String, Integer>() {
             {
@@ -420,9 +138,9 @@ class PauserTest {
       int pauseDuration = 1;
       Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
       doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
-      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
       doNothing().when(requestCoordinator).pause(true, null);
-      doNothing().when(requestCoordinator).unpause();
+      doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
 
       // Act & Assert
       PausedDuration actual = assertDoesNotThrow(() -> pauser.pause(pauseDuration, 3000L));
@@ -432,12 +150,442 @@ class PauserTest {
 
       mockedTime.close();
     }
+
+    @Test
+    void pause_LessThanOnePauseDuration_ShouldThrowIllegalArgumentException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 0;
+      Pauser pauser = new Pauser(namespace, helmReleaseName);
+
+      // Act & Assert
+      IllegalArgumentException thrown =
+          assertThrows(IllegalArgumentException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "pauseDuration is required to be greater than 0 millisecond.", thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenFirstGetTargetThrowException_ShouldThrowPauserException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doThrow(RuntimeException.class).when(pauser).getTarget();
+
+      // Act & Assert
+      PauserException thrown =
+          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals("Failed to find the target pods to pause.", thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenGetRequestCoordinatorThrowException_ShouldThrowPauserException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).when(pauser).getTarget();
+      doThrow(RuntimeException.class).when(pauser).getRequestCoordinator(targetBeforePause);
+
+      // Act & Assert
+      PauserException thrown =
+          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals("Failed to initialize the request coordinator.", thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenPauseInternalThrowException_ShouldThrowPauseFailedException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doThrow(RuntimeException.class)
+          .when(pauser)
+          .pauseInternal(requestCoordinator, pauseDuration, null);
+      doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
+      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      PauseFailedException thrown =
+          assertThrows(PauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "Pause operation failed. You cannot use the backup that was taken during this pause"
+              + " duration. You need to retry the pause operation from the beginning to take a"
+              + " backup. ",
+          thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenRequestCoordinatorPauseThrowException_ShouldThrowPauseFailedException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doThrow(RuntimeException.class).when(requestCoordinator).pause(true, null);
+      doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
+      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      PauseFailedException thrown =
+          assertThrows(PauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "Pause operation failed. You cannot use the backup that was taken during this pause"
+              + " duration. You need to retry the pause operation from the beginning to take a"
+              + " backup. ",
+          thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenInstantNowThrowException_ShouldThrowPauseFailedException()
+        throws PauserException {
+      // Arrange
+      MockedStatic<Instant> mockedTime = mockStatic(Instant.class);
+      mockedTime.when(() -> Instant.now()).thenThrow(RuntimeException.class);
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
+      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      PauseFailedException thrown =
+          assertThrows(PauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "Pause operation failed. You cannot use the backup that was taken during this pause"
+              + " duration. You need to retry the pause operation from the beginning to take a"
+              + " backup. ",
+          thrown.getMessage());
+
+      mockedTime.close();
+    }
+
+    @Test
+    void pause_WhenSleepThrowException_ShouldThrowPauseFailedException() throws PauserException {
+      // Arrange
+      int pauseDuration = 1;
+      MockedStatic<Uninterruptibles> mockedSleep = mockStatic(Uninterruptibles.class);
+      mockedSleep
+          .when(() -> Uninterruptibles.sleepUninterruptibly(pauseDuration, TimeUnit.MILLISECONDS))
+          .thenThrow(RuntimeException.class);
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
+      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      PauseFailedException thrown =
+          assertThrows(PauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "Pause operation failed. You cannot use the backup that was taken during this pause"
+              + " duration. You need to retry the pause operation from the beginning to take a"
+              + " backup. ",
+          thrown.getMessage());
+
+      mockedSleep.close();
+    }
+
+    @Test
+    void pause_WhenUnpauseWithRetryThrowException_ShouldThrowUnpauseFailedException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+
+      Instant startTime = Instant.now().minus(5, SECONDS);
+      Instant endTime = Instant.now().plus(5, SECONDS);
+      MockedStatic<Instant> mockedTime = mockStatic(Instant.class);
+      mockedTime.when(() -> Instant.now()).thenReturn(startTime).thenReturn(endTime);
+
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doThrow(RuntimeException.class)
+          .when(pauser)
+          .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
+      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      UnpauseFailedException thrown =
+          assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          String.format(
+              "Unpause operation failed. Scalar products might still be in a paused state. You must"
+                  + " restart related pods by using the `kubectl rollout restart deployment %s`"
+                  + " command to unpause all pods. Note that the pause operations for taking backup"
+                  + " succeeded. You can use a backup that was taken during this pause duration:"
+                  + " Start Time = %s, End Time = %s. ",
+              dummyObjectName, startTime, endTime),
+          thrown.getMessage());
+
+      mockedTime.close();
+    }
+
+    @Test
+    void pause_WhenSecondGetTargetThrowException_ShouldThrowPauserException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doThrow(RuntimeException.class).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
+
+      // Act & Assert
+      PauserException thrown =
+          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "Failed to find the target pods to examine if the targets pods were updated during"
+              + " paused.",
+          thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenCompareTargetStatusThrowException_ShouldThrowStatusCheckFailedException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
+      doThrow(RuntimeException.class).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      StatusCheckFailedException thrown =
+          assertThrows(StatusCheckFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "Status check failed. You cannot use the backup that was taken during this pause"
+              + " duration. You need to retry the pause operation from the beginning to take a"
+              + " backup. ",
+          thrown.getMessage());
+    }
+
+    @Test
+    void
+        pause_WhenCompareTargetStatusAndUnpauseWithRetryThrowException_ShouldThrowUnpauseFailedException()
+            throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doThrow(RuntimeException.class)
+          .when(pauser)
+          .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
+      doThrow(RuntimeException.class).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      UnpauseFailedException thrown =
+          assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "Unpause operation failed. Scalar products might still be in a paused state. You must"
+              + " restart related pods by using the `kubectl rollout restart deployment"
+              + " dummyObjectName` command to unpause all pods. ",
+          thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenTargetPodStatusChanged_ShouldThrowStatusCheckFailedException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+
+      Map<String, Integer> podRestartCounts =
+          new HashMap<String, Integer>() {
+            {
+              put("dummyKey", 1);
+            }
+          };
+      Map<String, String> podResourceVersions =
+          new HashMap<String, String>() {
+            {
+              put("dummyKey", "dummyValue");
+            }
+          };
+      TargetStatus beforeTargetStatus =
+          new TargetStatus(podRestartCounts, podResourceVersions, "beforeDifferentValue");
+      TargetStatus afterTargetStatus =
+          new TargetStatus(podRestartCounts, podResourceVersions, "afterDifferentValue");
+      doReturn(beforeTargetStatus).when(targetBeforePause).getStatus();
+      doReturn(afterTargetStatus).when(targetAfterPause).getStatus();
+
+      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
+
+      // Act & Assert
+      PauseFailedException thrown =
+          assertThrows(PauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "The target pods were updated during the pause duration. You cannot use the backup that"
+              + " was taken during this pause duration. ",
+          thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenPauseAndUnpauseFailed_ShouldThrowUnpauseFailedException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doThrow(RuntimeException.class)
+          .when(pauser)
+          .pauseInternal(requestCoordinator, pauseDuration, null);
+      doThrow(RuntimeException.class)
+          .when(pauser)
+          .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
+      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      UnpauseFailedException thrown =
+          assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          String.format(
+              "Unpause operation failed. Scalar products might still be in a paused state. You"
+                  + " must restart related pods by using the `kubectl rollout restart deployment"
+                  + " %s` command to unpause all pods. Pause operation failed. You cannot use the"
+                  + " backup that was taken during this pause"
+                  + " duration. You need to retry the pause operation from the beginning to"
+                  + " take a backup. ",
+              dummyObjectName),
+          thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenUnpauseFailedAndTargetPodStatusChanged_ShouldThrowUnpauseFailedException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doThrow(RuntimeException.class)
+          .when(pauser)
+          .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
+      doReturn(false).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      UnpauseFailedException thrown =
+          assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          String.format(
+              "Unpause operation failed. Scalar products might still be in a paused state. You must"
+                  + " restart related pods by using the `kubectl rollout restart deployment %s`"
+                  + " command to unpause all pods. The target pods were updated during the pause"
+                  + " duration. You cannot use the backup that was taken during this pause"
+                  + " duration. ",
+              dummyObjectName),
+          thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenPauseAndUnpauseAndTargetPodStatusChanged_ShouldThrowUnpauseFailedException()
+        throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doThrow(RuntimeException.class)
+          .when(pauser)
+          .pauseInternal(requestCoordinator, pauseDuration, null);
+      doThrow(RuntimeException.class)
+          .when(pauser)
+          .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
+      doReturn(false).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      UnpauseFailedException thrown =
+          assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          String.format(
+              "Unpause operation failed. Scalar products might still be in a paused state. You"
+                  + " must restart related pods by using the `kubectl rollout restart deployment"
+                  + " %s` command to unpause all pods. Pause operation failed. You cannot use the"
+                  + " backup that was taken during this pause duration. You need to retry the pause"
+                  + " operation from the beginning to take a backup. The target pods were updated"
+                  + " during the pause duration. You cannot use the backup that was taken during"
+                  + " this pause duration. ",
+              dummyObjectName),
+          thrown.getMessage());
+    }
+
+    @Test
+    void pause_WhenPauseFailedAndTargetPodStatusChanged_ShouldThrowUnpauseFailedException()
+        throws PauserException { // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
+      doThrow(RuntimeException.class)
+          .when(pauser)
+          .pauseInternal(requestCoordinator, pauseDuration, null);
+      doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
+      doReturn(false).when(pauser).compareTargetStatus(any(), any());
+
+      // Act & Assert
+      PauseFailedException thrown =
+          assertThrows(PauseFailedException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "Pause operation failed. You cannot use the backup that was taken during this pause"
+              + " duration. You need to retry the pause operation from the beginning to take a"
+              + " backup. The target pods were updated during the pause duration. You cannot use"
+              + " the backup that was taken during this pause duration. ",
+          thrown.getMessage());
+    }
   }
 
   @Nested
-  class MethodUnpauseWithRetry {
+  class UnpauseWithRetry {
     @Test
-    void WhenUnpauseSucceededReturnWithoutException() throws PauserException {
+    void unpauseWithRetry_WhenUnpauseSucceeded_ReturnWithoutException() throws PauserException {
       // Arrange
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
@@ -446,12 +594,11 @@ class PauserTest {
 
       // Act & Assert
       assertDoesNotThrow(
-          () ->
-              pauser.unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT, targetSnapshot));
+          () -> pauser.unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT));
     }
 
     @Test
-    void WhenExceptionOccurShouldRetryThreeTimes() throws PauserException {
+    void unpauseWithRetry_WhenExceptionOccur_ShouldRetryThreeTimes() throws PauserException {
       // Arrange
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
@@ -459,19 +606,10 @@ class PauserTest {
       doThrow(RuntimeException.class).when(requestCoordinator).unpause();
 
       // Act & Assert
-      PauserException thrown =
+      RuntimeException thrown =
           assertThrows(
-              PauserException.class,
-              () ->
-                  pauser.unpauseWithRetry(
-                      requestCoordinator, MAX_UNPAUSE_RETRY_COUNT, targetSnapshot));
-      assertEquals(
-          "Failed to unpause Scalar product. They are still in paused. You must restart related"
-              + " pods by using the `kubectl rollout restart deployment "
-              + dummyObjectName
-              + "` command to"
-              + " unpause all pods.",
-          thrown.getMessage());
+              RuntimeException.class,
+              () -> pauser.unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT));
       verify(requestCoordinator, times(MAX_UNPAUSE_RETRY_COUNT)).unpause();
     }
   }

--- a/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
@@ -29,7 +29,7 @@ class PauserTest {
   private TargetSnapshot targetAfterPause;
   private V1Deployment deployment;
   private V1ObjectMeta objectMeta;
-  private final String dummyObjectName = "dummyObjectName";
+  private static final String DUMMY_OBJECT_NAME = "dummyObjectName";
 
   @BeforeEach
   void beforeEach() throws PauserException {
@@ -44,7 +44,7 @@ class PauserTest {
     doReturn(deployment).when(targetBeforePause).getDeployment();
     doReturn(deployment).when(targetAfterPause).getDeployment();
     doReturn(objectMeta).when(deployment).getMetadata();
-    doReturn(dummyObjectName).when(objectMeta).getName();
+    doReturn(DUMMY_OBJECT_NAME).when(objectMeta).getName();
   }
 
   @AfterEach
@@ -337,7 +337,7 @@ class PauserTest {
                   + " command to unpause all pods. Note that the pause operations for taking backup"
                   + " succeeded. You can use a backup that was taken during this pause duration:"
                   + " Start Time = %s, End Time = %s. ",
-              dummyObjectName, startTime, endTime),
+              DUMMY_OBJECT_NAME, startTime, endTime),
           thrown.getMessage());
 
       mockedTime.close();
@@ -410,9 +410,11 @@ class PauserTest {
       UnpauseFailedException thrown =
           assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
       assertEquals(
-          "Unpause operation failed. Scalar products might still be in a paused state. You must"
-              + " restart related pods by using the `kubectl rollout restart deployment"
-              + " dummyObjectName` command to unpause all pods. ",
+          String.format(
+              "Unpause operation failed. Scalar products might still be in a paused state. You must"
+                  + " restart related pods by using the `kubectl rollout restart deployment"
+                  + " %s` command to unpause all pods. ",
+              DUMMY_OBJECT_NAME),
           thrown.getMessage());
     }
 
@@ -487,7 +489,7 @@ class PauserTest {
                   + " backup that was taken during this pause"
                   + " duration. You need to retry the pause operation from the beginning to"
                   + " take a backup. ",
-              dummyObjectName),
+              DUMMY_OBJECT_NAME),
           thrown.getMessage());
     }
 
@@ -517,7 +519,7 @@ class PauserTest {
                   + " command to unpause all pods. The target pods were updated during the pause"
                   + " duration. You cannot use the backup that was taken during this pause"
                   + " duration. ",
-              dummyObjectName),
+              DUMMY_OBJECT_NAME),
           thrown.getMessage());
     }
 
@@ -551,7 +553,7 @@ class PauserTest {
                   + " operation from the beginning to take a backup. The target pods were updated"
                   + " during the pause duration. You cannot use the backup that was taken during"
                   + " this pause duration. ",
-              dummyObjectName),
+              DUMMY_OBJECT_NAME),
           thrown.getMessage());
     }
 

--- a/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
@@ -214,7 +214,7 @@ class PauserTest {
           .when(pauser)
           .pauseInternal(requestCoordinator, pauseDuration, null);
       doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
-      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+      doReturn(true).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       PauseFailedException thrown =
@@ -238,7 +238,7 @@ class PauserTest {
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
       doThrow(RuntimeException.class).when(requestCoordinator).pause(true, null);
       doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
-      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+      doReturn(true).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       PauseFailedException thrown =
@@ -263,7 +263,7 @@ class PauserTest {
       doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
       doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
-      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+      doReturn(true).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       PauseFailedException thrown =
@@ -291,7 +291,7 @@ class PauserTest {
       doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
       doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
-      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+      doReturn(true).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       PauseFailedException thrown =
@@ -325,7 +325,7 @@ class PauserTest {
       doThrow(RuntimeException.class)
           .when(pauser)
           .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
-      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+      doReturn(true).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       UnpauseFailedException thrown =
@@ -394,7 +394,7 @@ class PauserTest {
     }
 
     @Test
-    void pause_WhenCompareTargetStatusThrowException_ShouldThrowStatusCheckFailedException()
+    void pause_WhenTargetStatusEqualsThrowException_ShouldThrowStatusCheckFailedException()
         throws PauserException {
       // Arrange
       String namespace = "dummyNs";
@@ -405,7 +405,7 @@ class PauserTest {
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
       doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
       doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
-      doThrow(RuntimeException.class).when(pauser).compareTargetStatus(any(), any());
+      doThrow(RuntimeException.class).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       StatusCheckFailedException thrown =
@@ -432,7 +432,7 @@ class PauserTest {
       doThrow(RuntimeException.class)
           .when(pauser)
           .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
-      doThrow(RuntimeException.class).when(pauser).compareTargetStatus(any(), any());
+      doThrow(RuntimeException.class).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       UnpauseFailedException thrown =
@@ -504,7 +504,7 @@ class PauserTest {
       doThrow(RuntimeException.class)
           .when(pauser)
           .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
-      doReturn(true).when(pauser).compareTargetStatus(any(), any());
+      doReturn(true).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       UnpauseFailedException thrown =
@@ -535,7 +535,7 @@ class PauserTest {
       doThrow(RuntimeException.class)
           .when(pauser)
           .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
-      doReturn(false).when(pauser).compareTargetStatus(any(), any());
+      doReturn(false).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       UnpauseFailedException thrown =
@@ -567,7 +567,7 @@ class PauserTest {
       doThrow(RuntimeException.class)
           .when(pauser)
           .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
-      doReturn(false).when(pauser).compareTargetStatus(any(), any());
+      doReturn(false).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       UnpauseFailedException thrown =
@@ -598,7 +598,7 @@ class PauserTest {
           .when(pauser)
           .pauseInternal(requestCoordinator, pauseDuration, null);
       doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
-      doReturn(false).when(pauser).compareTargetStatus(any(), any());
+      doReturn(false).when(pauser).targetStatusEquals(any(), any());
 
       // Act & Assert
       PauseFailedException thrown =

--- a/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
@@ -312,16 +312,15 @@ class PauserTest {
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
       int pauseDuration = 1;
-
       Instant startTime = Instant.now().minus(5, SECONDS);
       Instant endTime = Instant.now().plus(5, SECONDS);
-      MockedStatic<Instant> mockedTime = mockStatic(Instant.class);
-      mockedTime.when(() -> Instant.now()).thenReturn(startTime).thenReturn(endTime);
 
       Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      PausedDuration pausedDuration = new PausedDuration(startTime, endTime);
+
       doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
-      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doReturn(pausedDuration).when(pauser).pauseInternal(any(), anyInt(), anyLong());
       doThrow(RuntimeException.class)
           .when(pauser)
           .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
@@ -335,12 +334,9 @@ class PauserTest {
               "Unpause operation failed. Scalar products might still be in a paused state. You must"
                   + " restart related pods by using the `kubectl rollout restart deployment %s`"
                   + " command to unpause all pods. Note that the pause operations for taking backup"
-                  + " succeeded. You can use a backup that was taken during this pause duration:"
-                  + " Start Time = %s, End Time = %s. ",
+                  + " succeeded. You can use a backup that was taken during this pause duration. ",
               DUMMY_OBJECT_NAME, startTime, endTime),
           thrown.getMessage());
-
-      mockedTime.close();
     }
 
     @Test
@@ -350,10 +346,15 @@ class PauserTest {
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
       int pauseDuration = 1;
+      Instant startTime = Instant.now().minus(5, SECONDS);
+      Instant endTime = Instant.now().plus(5, SECONDS);
+
       Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      PausedDuration pausedDuration = new PausedDuration(startTime, endTime);
+
       doReturn(targetBeforePause).doThrow(RuntimeException.class).when(pauser).getTarget();
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
-      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doReturn(pausedDuration).when(pauser).pauseInternal(any(), anyInt(), anyLong());
       doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
 
       // Act & Assert
@@ -373,10 +374,15 @@ class PauserTest {
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
       int pauseDuration = 1;
+      Instant startTime = Instant.now().minus(5, SECONDS);
+      Instant endTime = Instant.now().plus(5, SECONDS);
+
       Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      PausedDuration pausedDuration = new PausedDuration(startTime, endTime);
+
       doReturn(targetBeforePause).doThrow(RuntimeException.class).when(pauser).getTarget();
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
-      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doReturn(pausedDuration).when(pauser).pauseInternal(any(), anyInt(), anyLong());
       doThrow(RuntimeException.class)
           .when(pauser)
           .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
@@ -400,10 +406,15 @@ class PauserTest {
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
       int pauseDuration = 1;
+      Instant startTime = Instant.now().minus(5, SECONDS);
+      Instant endTime = Instant.now().plus(5, SECONDS);
+
       Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      PausedDuration pausedDuration = new PausedDuration(startTime, endTime);
+
       doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
-      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doReturn(pausedDuration).when(pauser).pauseInternal(any(), anyInt(), anyLong());
       doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
       doThrow(RuntimeException.class).when(pauser).targetStatusEquals(any(), any());
 
@@ -425,10 +436,15 @@ class PauserTest {
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
       int pauseDuration = 1;
+      Instant startTime = Instant.now().minus(5, SECONDS);
+      Instant endTime = Instant.now().plus(5, SECONDS);
+
       Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      PausedDuration pausedDuration = new PausedDuration(startTime, endTime);
+
       doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
-      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doReturn(pausedDuration).when(pauser).pauseInternal(any(), anyInt(), anyLong());
       doThrow(RuntimeException.class)
           .when(pauser)
           .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);
@@ -453,7 +469,12 @@ class PauserTest {
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
       int pauseDuration = 1;
+      Instant startTime = Instant.now().minus(5, SECONDS);
+      Instant endTime = Instant.now().plus(5, SECONDS);
+
       Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      PausedDuration pausedDuration = new PausedDuration(startTime, endTime);
+
       doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
 
@@ -476,7 +497,7 @@ class PauserTest {
       doReturn(beforeTargetStatus).when(targetBeforePause).getStatus();
       doReturn(afterTargetStatus).when(targetAfterPause).getStatus();
 
-      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doReturn(pausedDuration).when(pauser).pauseInternal(any(), anyInt(), anyLong());
       doNothing().when(pauser).unpauseWithRetry(any(), anyInt());
 
       // Act & Assert
@@ -528,10 +549,15 @@ class PauserTest {
       String namespace = "dummyNs";
       String helmReleaseName = "dummyRelease";
       int pauseDuration = 1;
+      Instant startTime = Instant.now().minus(5, SECONDS);
+      Instant endTime = Instant.now().plus(5, SECONDS);
+
       Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      PausedDuration pausedDuration = new PausedDuration(startTime, endTime);
+
       doReturn(targetBeforePause).doReturn(targetAfterPause).when(pauser).getTarget();
       doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetBeforePause);
-      doNothing().when(pauser).pauseInternal(any(), anyInt(), anyLong());
+      doReturn(pausedDuration).when(pauser).pauseInternal(any(), anyInt(), anyLong());
       doThrow(RuntimeException.class)
           .when(pauser)
           .unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT);

--- a/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
@@ -330,11 +330,9 @@ class PauserTest {
       UnpauseFailedException thrown =
           assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
       assertEquals(
-          String.format(
-              "Unpause operation failed. Scalar products might still be in a paused state. You must"
-                  + " restart related pods by using the `kubectl rollout restart deployment %s`"
-                  + " command to unpause all pods. ",
-              DUMMY_OBJECT_NAME, startTime, endTime),
+          "Unpause operation failed. Scalar products might still be in a paused state. You must"
+              + " restart related pods by using the `kubectl rollout restart deployment"
+              + " <DEPLOYMENT_NAME>` command to unpause all pods. ",
           thrown.getMessage());
     }
 
@@ -390,11 +388,9 @@ class PauserTest {
       UnpauseFailedException thrown =
           assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
       assertEquals(
-          String.format(
-              "Unpause operation failed. Scalar products might still be in a paused state. You"
-                  + " must restart related pods by using the `kubectl rollout restart deployment"
-                  + " %s` command to unpause all pods. ",
-              DUMMY_OBJECT_NAME),
+          "Unpause operation failed. Scalar products might still be in a paused state. You must"
+              + " restart related pods by using the `kubectl rollout restart deployment"
+              + " <DEPLOYMENT_NAME>` command to unpause all pods. ",
           thrown.getMessage());
     }
 
@@ -453,11 +449,9 @@ class PauserTest {
       UnpauseFailedException thrown =
           assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
       assertEquals(
-          String.format(
-              "Unpause operation failed. Scalar products might still be in a paused state. You must"
-                  + " restart related pods by using the `kubectl rollout restart deployment"
-                  + " %s` command to unpause all pods. ",
-              DUMMY_OBJECT_NAME),
+          "Unpause operation failed. Scalar products might still be in a paused state. You must"
+              + " restart related pods by using the `kubectl rollout restart deployment"
+              + " <DEPLOYMENT_NAME>` command to unpause all pods. ",
           thrown.getMessage());
     }
 
@@ -530,14 +524,11 @@ class PauserTest {
       UnpauseFailedException thrown =
           assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
       assertEquals(
-          String.format(
-              "Unpause operation failed. Scalar products might still be in a paused state. You"
-                  + " must restart related pods by using the `kubectl rollout restart deployment"
-                  + " %s` command to unpause all pods. Pause operation failed. You cannot use the"
-                  + " backup that was taken during this pause"
-                  + " duration. You need to retry the pause operation from the beginning to"
-                  + " take a backup. ",
-              DUMMY_OBJECT_NAME),
+          "Unpause operation failed. Scalar products might still be in a paused state. You must"
+              + " restart related pods by using the `kubectl rollout restart deployment"
+              + " <DEPLOYMENT_NAME>` command to unpause all pods. Pause operation failed. You"
+              + " cannot use the backup that was taken during this pause duration. You need to"
+              + " retry the pause operation from the beginning to take a backup. ",
           thrown.getMessage());
     }
 
@@ -566,13 +557,11 @@ class PauserTest {
       UnpauseFailedException thrown =
           assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
       assertEquals(
-          String.format(
-              "Unpause operation failed. Scalar products might still be in a paused state. You must"
-                  + " restart related pods by using the `kubectl rollout restart deployment %s`"
-                  + " command to unpause all pods. The target pods were updated during the pause"
-                  + " duration. You cannot use the backup that was taken during this pause"
-                  + " duration. ",
-              DUMMY_OBJECT_NAME),
+          "Unpause operation failed. Scalar products might still be in a paused state. You must"
+              + " restart related pods by using the `kubectl rollout restart deployment"
+              + " <DEPLOYMENT_NAME>` command to unpause all pods. The target pods were updated"
+              + " during the pause duration. You cannot use the backup that was taken during"
+              + " this pause duration. ",
           thrown.getMessage());
     }
 
@@ -598,15 +587,13 @@ class PauserTest {
       UnpauseFailedException thrown =
           assertThrows(UnpauseFailedException.class, () -> pauser.pause(pauseDuration, null));
       assertEquals(
-          String.format(
-              "Unpause operation failed. Scalar products might still be in a paused state. You"
-                  + " must restart related pods by using the `kubectl rollout restart deployment"
-                  + " %s` command to unpause all pods. Pause operation failed. You cannot use the"
-                  + " backup that was taken during this pause duration. You need to retry the pause"
-                  + " operation from the beginning to take a backup. The target pods were updated"
-                  + " during the pause duration. You cannot use the backup that was taken during"
-                  + " this pause duration. ",
-              DUMMY_OBJECT_NAME),
+          "Unpause operation failed. Scalar products might still be in a paused state. You must"
+              + " restart related pods by using the `kubectl rollout restart deployment"
+              + " <DEPLOYMENT_NAME>` command to unpause all pods. Pause operation failed. You"
+              + " cannot use the backup that was taken during this pause duration. You need to"
+              + " retry the pause operation from the beginning to take a backup. The target"
+              + " pods were updated during the pause duration. You cannot use the backup that"
+              + " was taken during this pause duration. ",
           thrown.getMessage());
     }
 

--- a/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
@@ -333,8 +333,7 @@ class PauserTest {
           String.format(
               "Unpause operation failed. Scalar products might still be in a paused state. You must"
                   + " restart related pods by using the `kubectl rollout restart deployment %s`"
-                  + " command to unpause all pods. Note that the pause operations for taking backup"
-                  + " succeeded. You can use a backup that was taken during this pause duration. ",
+                  + " command to unpause all pods. ",
               DUMMY_OBJECT_NAME, startTime, endTime),
           thrown.getMessage());
     }

--- a/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/PauserTest.java
@@ -1,0 +1,232 @@
+package com.scalar.admin.kubernetes;
+
+import static com.scalar.admin.kubernetes.Pauser.MAX_UNPAUSE_RETRY_COUNT;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.scalar.admin.RequestCoordinator;
+import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.util.Config;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class PauserTest {
+
+  private MockedStatic<Config> mockedConfig;
+  private RequestCoordinator requestCoordinator;
+  private TargetSnapshot targetSnapshot;
+  private TargetSelector targetSelector;
+  private V1Deployment deployment;
+  private V1ObjectMeta objectMeta;
+  private final String dummyObjectName = "dummyObjectName";
+
+  @BeforeEach
+  void beforeEach() throws PauserException {
+    mockedConfig = mockStatic(Config.class);
+    mockedConfig.when(() -> Config.defaultClient()).thenReturn(null);
+    requestCoordinator = mock(RequestCoordinator.class);
+    targetSnapshot = mock(TargetSnapshot.class);
+    targetSelector = mock(TargetSelector.class);
+    deployment = mock(V1Deployment.class);
+    objectMeta = mock(V1ObjectMeta.class);
+
+    when(targetSnapshot.getDeployment()).thenReturn(deployment);
+    when(deployment.getMetadata()).thenReturn(objectMeta);
+    when(objectMeta.getName()).thenReturn(dummyObjectName);
+    when(targetSelector.select()).thenReturn(targetSnapshot);
+  }
+
+  @AfterEach
+  void afterEach() {
+    mockedConfig.close();
+  }
+
+  @Nested
+  class ConstructorPauser {
+    @Test
+    void WithCorrectArgsReturnPauser() throws PauserException, IOException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+
+      // Act & Assert
+      assertDoesNotThrow(() -> new Pauser(namespace, helmReleaseName));
+    }
+
+    @Test
+    void WithNullNamespaceShouldThrowException() {
+      // Arrange
+      String namespace = null;
+      String helmReleaseName = "dummyRelease";
+
+      // Act & Assert
+      IllegalArgumentException thrown =
+          assertThrows(
+              IllegalArgumentException.class, () -> new Pauser(namespace, helmReleaseName));
+      assertEquals("namespace is required", thrown.getMessage());
+    }
+
+    @Test
+    void WithNullHelmReleaseNameShouldThrowException() {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = null;
+
+      // Act & Assert
+      IllegalArgumentException thrown =
+          assertThrows(
+              IllegalArgumentException.class, () -> new Pauser(namespace, helmReleaseName));
+      assertEquals("helmReleaseName is required", thrown.getMessage());
+    }
+
+    @Test
+    void WhenSetDefaultApiClientThrowIOExceptionShouldThrowException() {
+      // Arrange
+      mockedConfig.when(() -> Config.defaultClient()).thenThrow(IOException.class);
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+
+      // Act & Assert
+      PauserException thrown =
+          assertThrows(PauserException.class, () -> new Pauser(namespace, helmReleaseName));
+      assertEquals("Failed to set default Kubernetes client.", thrown.getMessage());
+    }
+  }
+
+  @Nested
+  class MethodPause {
+    @Test
+    void LessThanOnePauseDurationShouldThrowException() throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 0;
+      Pauser pauser = new Pauser(namespace, helmReleaseName);
+
+      // Act & Assert
+      IllegalArgumentException thrown =
+          assertThrows(IllegalArgumentException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals(
+          "pauseDuration is required to be greater than 0 millisecond.", thrown.getMessage());
+    }
+
+    @Test
+    void WhenFirstTargetSelectorThrowExceptionShouldThrowException() throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = new Pauser(namespace, helmReleaseName);
+      when(targetSelector.select()).thenThrow(RuntimeException.class);
+
+      // Act & Assert
+      PauserException thrown =
+          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals("Failed to find the target pods to pause.", thrown.getMessage());
+    }
+
+    @Test
+    void WhenGetRequestCoordinatorThrowExceptionShouldThrowException() throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetSnapshot).when(pauser).getTarget();
+      doThrow(RuntimeException.class).when(pauser).getRequestCoordinator(targetSnapshot);
+      doNothing().when(requestCoordinator).unpause();
+
+      // Act & Assert
+      PauserException thrown =
+          assertThrows(PauserException.class, () -> pauser.pause(pauseDuration, null));
+      assertEquals("Failed to initialize the coordinator.", thrown.getMessage());
+    }
+
+    @Test
+    void WhenCoordinatorPauseThrowExceptionShouldRunUnpause() throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      int pauseDuration = 1;
+      Pauser pauser = spy(new Pauser(namespace, helmReleaseName));
+      doReturn(targetSnapshot).when(pauser).getTarget();
+      doReturn(requestCoordinator).when(pauser).getRequestCoordinator(targetSnapshot);
+      doThrow(RuntimeException.class).when(requestCoordinator).pause(true, null);
+      doNothing().when(requestCoordinator).unpause();
+
+      // Act & Assert
+      RuntimeException thrown =
+          assertThrows(RuntimeException.class, () -> pauser.pause(pauseDuration, null));
+      verify(pauser, times(1))
+          .unpauseWithRetry(
+              any(RequestCoordinator.class),
+              eq(MAX_UNPAUSE_RETRY_COUNT),
+              any(TargetSnapshot.class));
+    }
+
+    @Test
+    void WhenInstantNowThrowExceptionShouldRunUnpause() {}
+
+    @Test
+    void WhenSleepThrowExceptionShouldRunUnpause() {}
+
+    @Test
+    void WhenUnpauseThrowExceptionShouldRunUnpauseAgain() {}
+
+    @Test
+    void WhenSecondTargetSelectorThrowExceptionShouldThrowException() {}
+
+    @Test
+    void WhenTargetPodStatusChangedShouldThrowException() {}
+
+    @Test
+    void WhenPauseSucceededReturnPausedDuration() {}
+  }
+
+  @Nested
+  class MethodUnpauseWithRetry {
+    @Test
+    void WhenUnpauseSucceededReturnWithoutException() throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      Pauser pauser = new Pauser(namespace, helmReleaseName);
+      doNothing().when(requestCoordinator).unpause();
+
+      // Act & Assert
+      assertDoesNotThrow(
+          () ->
+              pauser.unpauseWithRetry(requestCoordinator, MAX_UNPAUSE_RETRY_COUNT, targetSnapshot));
+    }
+
+    @Test
+    void WhenExceptionOccurShouldRetryThreeTimes() throws PauserException {
+      // Arrange
+      String namespace = "dummyNs";
+      String helmReleaseName = "dummyRelease";
+      Pauser pauser = new Pauser(namespace, helmReleaseName);
+      doThrow(RuntimeException.class).when(requestCoordinator).unpause();
+
+      // Act & Assert
+      PauserException thrown =
+          assertThrows(
+              PauserException.class,
+              () ->
+                  pauser.unpauseWithRetry(
+                      requestCoordinator, MAX_UNPAUSE_RETRY_COUNT, targetSnapshot));
+      assertEquals(
+          "Failed to unpause Scalar product. They are still in paused. You must restart related"
+              + " pods by using the `kubectl rollout restart deployment "
+              + dummyObjectName
+              + "` command to"
+              + " unpause all pods.",
+          thrown.getMessage());
+      verify(requestCoordinator, times(MAX_UNPAUSE_RETRY_COUNT)).unpause();
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR added error handling to the `Puaser.pause()` method.

Previously, there is no error handling, and it might cause `Scalar products keep pause state forever` when some error occurs.

In other words, it might cause some issues like the system down.

To address such issue, I added error handling. And now, if some error occurs, the `Pauser` tries to run `unpause()` method several times to make Scalar products the unpause state as long as possible.

Also, I updated it to throw the `PauseException`. So, the caller (CLI or some other tools that implement this library) can notice the above issue and handle it on their side.

Please take a look!

## Related issues and/or PRs

N/A

## Changes made (By copilot)

This pull request introduces improvements to the `Pauser` class in `lib/src/main/java/com/scalar/admin/kubernetes/Pauser.java` to enhance error handling, testability, and maintainability. It also includes a minor addition to the project's dependencies in `lib/build.gradle`. The most important changes are grouped below by theme.

### Enhancements to error handling:
* Improved error handling in the `pause` method by adding nested `try-catch` blocks to ensure that the `unpauseWithRetry` method is called even if the `pause` operation fails. This ensures a fallback mechanism for unpausing pods and provides detailed error messages for critical failures.
* Updated the `unpauseWithRetry` method to throw a `PauserException` with a detailed error message when retry attempts fail. This ensures that users are informed of the critical issue and the steps required to resolve it.

### Testability improvements:
* Annotated the `MAX_UNPAUSE_RETRY_COUNT`, `unpauseWithRetry`, `getTarget`, and `getRequestCoordinator` members with `@VisibleForTesting` to make them accessible for unit testing. This improves the testability of the `Pauser` class. [[1]](diffhunk://#diff-529e2e818d31d239079b031928623cab070acd5743e317b3d709c34e6e52b394L37-R38) [[2]](diffhunk://#diff-529e2e818d31d239079b031928623cab070acd5743e317b3d709c34e6e52b394L116-R143) [[3]](diffhunk://#diff-529e2e818d31d239079b031928623cab070acd5743e317b3d709c34e6e52b394L126-R179)

### Dependency updates:
* Added the `mockito-inline` library to the `testImplementation` dependencies in `lib/build.gradle` to support mocking of static methods and final classes in tests.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
