### PR TITLE
Update CI configurations

### DIFF
--- a/.github/manifests/scalardb.yaml
+++ b/.github/manifests/scalardb.yaml
@@ -1,4 +1,6 @@
 scalardb:
+  imagePullSecrets:
+  - name: reg-docker-secrets
   databaseProperties: |
     scalar.db.storage=jdbc
     scalar.db.contact_points=jdbc:postgresql://dummy.default.svc.cluster.local:5432/postgres

--- a/.github/manifests/scalardl-audit.yaml
+++ b/.github/manifests/scalardl-audit.yaml
@@ -1,4 +1,6 @@
 auditor:
+  image:
+    repository: "ghcr.io/scalar-labs/scalardl-auditor"
   auditorProperties: |
     scalar.db.storage=jdbc
     scalar.db.contact_points=jdbc:postgresql://dummy.default.svc.cluster.local:5432/postgres


### PR DESCRIPTION
## Description

This PR updates the manifests file for CI as follows:

- Change the container image of ScalarDL Auditor.
  - Recently, we updated the default container image of ScalarDL on the Helm Chart side. Now, it uses `ghcr.io/scalar-labs/scalardl-auditor-byol` by default, which requires a license key to run. However, in the CI environment, we don't set the license key. So, the CI fails.
  - To address this issue, I specified the container image `ghcr.io/scalar-labs/scalardl-auditor` explicitly. This image does not require the license key since it's for internal developers.
- Set `imagePullSecrets` for ScalarDB Server.
  - Recently, we updated the visibility of the ScalarDB Server container registry from `public` to `private` because it's already deprecated. As a result, we need credentials to pull the container image of ScalarDB Server.
  - To address this issue, I specified the `imagePullSecrets` to set credentials. This configuration allows the CI environment to pull the private container images.

Please take a look!

## Related issues and/or PRs

- https://github.com/scalar-labs/scalar-admin-for-kubernetes/actions/runs/14701917832/job/41252919172
- https://github.com/scalar-labs/scalar-admin-for-kubernetes/actions/runs/14702584212/job/41254991642

## Changes made

- Set `ghcr.io/scalar-labs/scalardl-auditor` in the custom values file for CI.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A

