### PR TITLE
Add workflow_dispatch trigger to GitHub Actions workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   e2e:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - main
+  workflow_dispatch:
 
 jobs:
   unit-test:


### PR DESCRIPTION
## Description

This enables manual execution of workflows from the GitHub UI, which helps when CI workflows are not triggered automatically.

## Related issues and/or PRs

For context, CI didn't start automatically for the following PR
#37 

## Changes made

Changes:
- Add workflow_dispatch to e2e.yml
- Add workflow_dispatch to release.yml
- Add workflow_dispatch to unit-test.yml


## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

> Provide any additional information or notes that may be relevant to the reviewers or stakeholders.

