### PR TITLE
Deploy PostgreSQL as backend DB in CI

### DIFF
--- a/.github/manifests/postgresql.yaml
+++ b/.github/manifests/postgresql.yaml
@@ -1,0 +1,11 @@
+primary:
+  persistence:
+    enabled: false
+  resourcesPreset: none
+  extendedConfiguration: |
+    max_connections = 4096
+
+auth:
+  postgresPassword: postgres
+
+postgresqlDataDir: /tmp/data

--- a/.github/manifests/scalardl.yaml
+++ b/.github/manifests/scalardl.yaml
@@ -1,7 +1,7 @@
 ledger:
   ledgerProperties: |
     scalar.db.storage=jdbc
-    scalar.db.contact_points=jdbc:postgresql://dummy.default.svc.cluster.local:5432/postgres
+    scalar.db.contact_points=jdbc:postgresql://postgresql.default.svc.cluster.local:5432/postgres
     scalar.db.username=postgres
     scalar.db.password=postgres
   imagePullSecrets:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,6 +48,14 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
+      - name: Deploy PostgreSQL as a backend database for Scalar products
+        run: |
+          helm install postgresql oci://registry-1.docker.io/bitnamicharts/postgresql -f .github/manifests/postgresql.yaml
+
+      - name: Wait for PostgreSQL is started
+        run: |
+          kubectl wait --for=condition=Available deployment/postgresql-postgresql --timeout 300s
+
       - name: Add Helm repository
         run: |
           helm repo add scalar-labs https://scalar-labs.github.io/helm-charts


### PR DESCRIPTION
@monkey-mas 

Previously, we didn't need to deploy a backend DB (e.g., PostgreSQL) since ScalarDB Cluster and ScalarDL (strictly, ScalarDB Core in their internal) didn't access a backend DB during their startup process.

However, recently, ScalarDB Core has always accessed the backend DB to get the isolation level information of the backend DB. In other words, ScalarDB Cluster and ScalarDL always access the backend DB during the startup process.

It causes the following error in the startup process:

```
Caused by: java.lang.RuntimeException: Failed to get transaction isolation level
        at com.scalar.db.storage.jdbc.JdbcUtils.requiresExplicitCommit(JdbcUtils.java:184)
        at com.scalar.db.storage.jdbc.JdbcDatabase.<init>(JdbcDatabase.java:80)
        at com.scalar.db.storage.jdbc.JdbcProvider.createDistributedStorage(JdbcProvider.java:17)
        at com.scalar.db.service.ProviderManager.createDistributedStorage(ProviderManager.java:68)
        at com.scalar.db.service.StorageFactory.getStorage(StorageFactory.java:34)
        at com.scalar.dl.ledger.service.LedgerModule.provideDistributedStorage(LedgerModule.java:149)
        at com.scalar.dl.ledger.service.LedgerModule$$FastClassByGuice$$cd46d.GUICE$TRAMPOLINE(<generated>)
        at com.scalar.dl.ledger.service.LedgerModule$$FastClassByGuice$$cd46d.apply(<generated>)

(omit)

Caused by: java.sql.SQLException: Cannot create PoolableConnectionFactory (The connection attempt failed.)
        at org.apache.commons.dbcp2.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:645)
        at org.apache.commons.dbcp2.BasicDataSource.createDataSource(BasicDataSource.java:546)
        at org.apache.commons.dbcp2.BasicDataSource.lambda$getConnection$0(BasicDataSource.java:712)
        at java.base/java.security.AccessController.doPrivileged(Unknown Source)
        at org.apache.commons.dbcp2.BasicDataSource.getConnection(BasicDataSource.java:714)
        at com.scalar.db.storage.jdbc.JdbcUtils.requiresExplicitCommit(JdbcUtils.java:181)
        ... 73 more
Caused by: org.postgresql.util.PSQLException: The connection attempt failed.
        at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:385)
        at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:57)
        at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:279)
        at org.postgresql.Driver.makeConnection(Driver.java:448)
        at org.postgresql.Driver.connect(Driver.java:298)
        at org.apache.commons.dbcp2.DriverConnectionFactory.createConnection(DriverConnectionFactory.java:52)
        at org.apache.commons.dbcp2.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:481)
        at org.apache.commons.dbcp2.BasicDataSource.validateConnectionFactory(BasicDataSource.java:114)
        at org.apache.commons.dbcp2.BasicDataSource.createPoolableConnectionFactory(BasicDataSource.java:641)
        ... 78 more
Caused by: java.net.UnknownHostException: dummy.default.svc.cluster.local
        at java.base/sun.nio.ch.NioSocketImpl.connect(Unknown Source)
        at java.base/java.net.SocksSocketImpl.connect(Unknown Source)
        at java.base/java.net.Socket.connect(Unknown Source)
        at org.postgresql.core.PGStream.createSocket(PGStream.java:261)
        at org.postgresql.core.PGStream.<init>(PGStream.java:122)
        at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:146)
        at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:289)
        ... 86 more
2026/05/27 05:46:45 Command exited with error: exit status 1
```

To address this error, we need to deploy an actual backend DB in the CI before we deploy ScalarDB Cluster and ScalarDL.

By deploying PostgreSQL, you can run ScalarDB Cluster and ScalarDL as follows:

```
$ kubectl get pod
NAME                                   READY   STATUS    RESTARTS   AGE
foo-scalardl-ledger-647d49986d-9wtjg   1/1     Running   0          8m30s
foo-scalardl-ledger-647d49986d-gvchr   1/1     Running   0          8m30s
foo-scalardl-ledger-647d49986d-m92fx   1/1     Running   0          8m30s
postgresql-0                           1/1     Running   0          10m
```
