### PR TITLE
Share one SQLite DB file across all pods via PVC

### DIFF
--- a/.github/manifests/scalardb-cluster.yaml
+++ b/.github/manifests/scalardb-cluster.yaml
@@ -6,9 +6,16 @@ scalardbCluster:
     scalar.db.cluster.membership.kubernetes.endpoint.namespace_name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAMESPACE_NAME}
     scalar.db.cluster.membership.kubernetes.endpoint.name=${env:SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME}
     scalar.db.storage=jdbc
-    scalar.db.contact_points=jdbc:sqlite:/tmp/sqlite.db?busy_timeout=10000
+    scalar.db.contact_points=jdbc:sqlite:/sqlite/tmp.db?busy_timeout=10000
   imagePullSecrets:
     - name: reg-docker-secrets
+  extraVolumes:
+    - name: sqlite
+      persistentVolumeClaim:
+        claimName: sqlite
+  extraVolumeMounts:
+    - name: sqlite
+      mountPath: /sqlite
 
 envoy:
   enabled: false

--- a/.github/manifests/scalardl-audit.yaml
+++ b/.github/manifests/scalardl-audit.yaml
@@ -3,7 +3,7 @@ auditor:
     repository: "ghcr.io/scalar-labs/scalardl-auditor"
   auditorProperties: |
     scalar.db.storage=jdbc
-    scalar.db.contact_points=jdbc:sqlite:/tmp/sqlite.db?busy_timeout=10000
+    scalar.db.contact_points=jdbc:sqlite:/sqlite/tmp.db?busy_timeout=10000
     scalar.dl.auditor.authentication.method=hmac
     scalar.dl.auditor.authentication.hmac.cipher_key=dummy-cipher-key
     scalar.dl.auditor.servers.authentication.hmac.secret_key=dummy-secret-key
@@ -11,6 +11,13 @@ auditor:
     - name: reg-docker-secrets
   authentication:
     method: "hmac"
+  extraVolumes:
+    - name: sqlite
+      persistentVolumeClaim:
+        claimName: sqlite
+  extraVolumeMounts:
+    - name: sqlite
+      mountPath: /sqlite
 
 envoy:
   enabled: false

--- a/.github/manifests/scalardl.yaml
+++ b/.github/manifests/scalardl.yaml
@@ -1,9 +1,16 @@
 ledger:
   ledgerProperties: |
     scalar.db.storage=jdbc
-    scalar.db.contact_points=jdbc:sqlite:/tmp/sqlite.db?busy_timeout=10000
+    scalar.db.contact_points=jdbc:sqlite:/sqlite/tmp.db?busy_timeout=10000
   imagePullSecrets:
     - name: reg-docker-secrets
+  extraVolumes:
+    - name: sqlite
+      persistentVolumeClaim:
+        claimName: sqlite
+  extraVolumeMounts:
+    - name: sqlite
+      mountPath: /sqlite
 
 envoy:
   enabled: false

--- a/.github/manifests/sqlite-pvc.yaml
+++ b/.github/manifests/sqlite-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sqlite
+spec:
+  # ReadWriteOnce is used because CI runs on a single-node kind cluster, where all pods are
+  # scheduled on the same node. local-path-provisioner (kind's default StorageClass) does not
+  # support ReadWriteMany unless sharedFileSystemPath is configured.
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 512Mi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           kubectl create secret docker-registry reg-docker-secrets --docker-server=${DOCKER_REGISTRY_SERVER} --docker-username=${DOCKER_REGISTRY_USERNAME} --docker-password=${DOCKER_REGISTRY_PASSWORD}
 
+      - name: Create PVC for SQLite
+        run: |
+          kubectl apply -f .github/manifests/sqlite-pvc.yaml
+
       - name: Deploy Scalar products to Kind
         run: |
           helm install foo scalar-labs/${{ matrix.productName }} -f .github/manifests/${{ matrix.productName }}.yaml


### PR DESCRIPTION
## Description

This PR updates the CI configurations to share one SQLite DB file in all pods.

This PR addresses the following comment in the previous PR:

- https://github.com/scalar-labs/scalar-admin-for-kubernetes/pull/41#discussion_r3315199258

In the current implementation, for example, in a case of ScalarDB Cluster, we deploy three ScalarDB Cluster pods in the CI, and all pods have their own independent SQLite DB file in each pod.

In other words, ScalarDB Cluster does not share one backend DB, so ScalarDB Cluster does not work properly as a cluster.

Therefore, I updated the CI to mount (share) one PV to all pods, and all pods can share one SQLite DB file. In this case, ScalarDB Cluster can work as a cluster.

> [!NOTE]
> 
> We deploy PV as `ReadWriteOnce`, which allows all pods in the same node to access the PV. In other words, the current implementation works if and only if we use single-node Kubernetes.
> 
> In the CI, we use a single-node kind cluster. So, it works. However, it does not work if you run this CI on a multiple-node Kubernetes cluster.

For now, we can run the test of Scalar Admin for Kubernetes with a separate SQLite file since we don't run any actual queries of ScalarDB or ScalarDL.

However, there are the following two concerns:

- In the future, we might add some new features to Scalar Admin for Kubernetes that run the actual queries against ScalarDB Cluster or ScalarDL.
  - In this case, the CI will be broken.
- A new developer or beginner of Scalar products might misunderstand how to use SQLite as a backend DB in Scalar products.
  - It might cause unexpected issues.

To address such concerns, I fixed the CI in this PR to share one SQLite DB file properly.

Please take a look!

## Related issues and/or PRs

- https://github.com/scalar-labs/scalar-admin-for-kubernetes/pull/41
  - The issue (independent SQLite DB file) was introduced in this PR.

## Changes made

- Create one PV to share one SQLite DB file in all pods in CI.
- Update configuration of Scalar products to mount the PV.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
