### PR TITLE
Introduce `--pod-discovery-mode` to support (Helm-free) pausing by Deployment name

### DIFF
--- a/.github/workflows/e2e-deployment.yml
+++ b/.github/workflows/e2e-deployment.yml
@@ -1,0 +1,96 @@
+name: Run the end-to-end test (deployment mode)
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  e2e-deployment:
+    runs-on: ubuntu-latest
+
+    env:
+      HELM_VERSION: v3.12.2
+      DOCKER_REGISTRY_PASSWORD: ${{ secrets.CR_PAT }}
+      DOCKER_REGISTRY_USERNAME: scalar-git
+      DOCKER_REGISTRY_SERVER: ghcr.io
+
+    strategy:
+      matrix:
+        product:
+          - productName: scalardb-cluster
+            deploymentName: scalardb-cluster-node
+            adminPort: 60053
+          - productName: scalardl
+            deploymentName: scalardl-ledger
+            adminPort: 50053
+          - productName: scalardl-audit
+            deploymentName: scalardl-auditor
+            adminPort: 40053
+
+    steps:
+
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: actions/checkout@v3
+
+      - name: Set version
+        id: version
+        run: |
+          VERSION=$(./gradlew :cli:properties -q | grep "version:" | awk '{print $2}')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - uses: helm/kind-action@v1.12.0
+        with:
+          cluster_name: kind
+          node_image: kindest/node:v1.35.0
+
+      - name: Set up helm command
+        uses: azure/setup-helm@v3
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Add Helm repository
+        run: |
+          helm repo add scalar-labs https://scalar-labs.github.io/helm-charts
+
+      - name: Create secret resource to pull the containers from GitHub Packages
+        run: |
+          kubectl create secret docker-registry reg-docker-secrets --docker-server=${DOCKER_REGISTRY_SERVER} --docker-username=${DOCKER_REGISTRY_USERNAME} --docker-password=${DOCKER_REGISTRY_PASSWORD}
+
+      - name: Create PVC for SQLite
+        run: |
+          kubectl apply -f .github/manifests/sqlite-pvc.yaml
+
+      - name: Deploy Scalar products to Kind
+        run: |
+          helm install foo scalar-labs/${{ matrix.product.productName }} -f .github/manifests/${{ matrix.product.productName }}.yaml
+
+      - name: Deploy client pod
+        run: |
+          kubectl apply -f .github/manifests/client-pod.yaml
+
+      - name: Wait for Scalar products are started
+        run: |
+          kubectl wait --for=condition=Available deployment/$(kubectl get deployment -l app.kubernetes.io/instance=foo,app.kubernetes.io/name=${{ matrix.product.productName }} -o jsonpath='{.items[0].metadata.name}') --timeout 300s
+
+      - name: Build Shadow Jar
+        run: ./gradlew shadowJar
+
+      - name: Copy Shadow Jar to tester Pod
+        run: |
+          kubectl wait --for=condition=Ready pod/java21 --timeout 300s
+          kubectl cp cli/build/libs/scalar-admin-for-kubernetes-cli-${{ steps.version.outputs.version }}.jar java21:/tmp
+
+      - name: Get deployment name
+        id: deployment
+        run: |
+          DEPLOYMENT_NAME=$(kubectl get deployment -l app.kubernetes.io/instance=foo,app.kubernetes.io/name=${{ matrix.product.productName }} -o jsonpath='{.items[0].metadata.name}')
+          echo "name=${DEPLOYMENT_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Run Shadow Jar with deployment mode
+        run: |
+          kubectl exec -it java21 -- java -jar /tmp/scalar-admin-for-kubernetes-cli-${{ steps.version.outputs.version }}.jar --pod-discovery-mode deployment --deployment-name ${{ steps.deployment.outputs.name }} --admin-port ${{ matrix.product.adminPort }} --namespace default

--- a/.github/workflows/e2e-helm-release.yml
+++ b/.github/workflows/e2e-helm-release.yml
@@ -1,4 +1,4 @@
-name: Run the end-to-end test
+name: Run the end-to-end test (helm-release mode)
 
 on:
   pull_request:
@@ -21,6 +21,11 @@ jobs:
           - scalardb-cluster
           - scalardl
           - scalardl-audit
+        testMode:
+          - name: without-pod-discovery-mode
+            args: "-r foo"
+          - name: with-pod-discovery-mode
+            args: "--pod-discovery-mode helm-release -r foo"
 
     steps:
 
@@ -79,6 +84,6 @@ jobs:
           kubectl wait --for=condition=Ready pod/java21 --timeout 300s
           kubectl cp cli/build/libs/scalar-admin-for-kubernetes-cli-${{ steps.version.outputs.version }}.jar java21:/tmp
 
-      - name: Run Shadow Jar
+      - name: Run Shadow Jar (${{ matrix.testMode.name }})
         run: |
-          kubectl exec -it java21 -- java -jar /tmp/scalar-admin-for-kubernetes-cli-${{ steps.version.outputs.version }}.jar -r foo
+          kubectl exec -it java21 -- java -jar /tmp/scalar-admin-for-kubernetes-cli-${{ steps.version.outputs.version }}.jar ${{ matrix.testMode.args }}

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ The `scalar-admin-for-kubernetes` CLI tool executes Kubernetes APIs in its inter
      - ScalarDL Ledger: 50053
      - ScalarDL Auditor: 40053
 
+     > **Important:** In deployment mode, the tool discovers pods using the Deployment's label selector and sends pause RPCs to the user-specified `--admin-port`. Unlike helm-release mode, there is no automatic Scalar-product label verification or admin port auto-detection. Ensure that `--deployment-name` and `--admin-port` point to the correct Scalar product Deployment.
+
 ## Run the CLI tool in a Kubernetes environment by using a Helm Chart
 
 For details on how to use a Helm Chart to deploy Scalar Admin for Kubernetes in a Kubernetes environment, see the following documentation based on the product you're using:

--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@ Scalar Admin for Kubernetes is a tool that creates a paused state for ScalarDB o
 
 ```console
 Usage: scalar-admin-for-kubernetes-cli [-h] [--tls]
+                                       [--admin-port=<adminPort>]
                                        [--ca-root-cert-path=<caRootCertPath>]
                                        [--ca-root-cert-pem=<caRootCertPem>]
-                                       [-d=<pauseDuration>] [-n=<namespace>]
-                                       [--override-authority=<overrideAuthority>
-                                       ] -r=<helmReleaseName>
+                                       [-d=<pauseDuration>]
+                                       [--deployment-name=<deploymentName>]
+                                       [-n=<namespace>]
+                                       [--override-authority=<overrideAuthority>]
+                                       [--pod-discovery-mode=<podDiscoveryMode>]
+                                       [-r=<helmReleaseName>]
                                        [-w=<maxPauseWaitTime>] [-z=<zoneId>]
 Scalar Admin pause tool for the Kubernetes environment
+      --admin-port=<adminPort>
+                             The port number of the admin interface of the
+                               Scalar product. Required when --pod-discovery-mode
+                               is deployment.
       --ca-root-cert-path=<caRootCertPath>
                              A path to a root certificate file for verifying
                                the server's certificate when wire encryption is
@@ -26,6 +34,10 @@ Scalar Admin pause tool for the Kubernetes environment
   -d, --pause-duration=<pauseDuration>
                              The duration of the pause period by millisecond.
                                5000 (5 seconds) by default.
+      --deployment-name=<deploymentName>
+                             The name of the Kubernetes Deployment for the
+                               Scalar product. Required when --pod-discovery-mode
+                               is deployment.
   -h, --help                 Display the help message.
   -n, --namespace=<namespace>
                              Namespace that Scalar products you want to pause
@@ -34,11 +46,15 @@ Scalar Admin pause tool for the Kubernetes environment
                              The value to be used as the expected authority in
                                the server's certificate when wire encryption is
                                enabled.
+      --pod-discovery-mode=<podDiscoveryMode>
+                             The mode to discover the target pods. Valid values:
+                               helm-release, deployment. helm-release by default.
   -r, --release-name=<helmReleaseName>
-                             Required. The helm release name that you specify
-                               when you run the `helm install <RELEASE_NAME>`
-                               command. You can see the <RELEASE_NAME> by using
-                               the `helm list` command.
+                             The helm release name that you specify when you run
+                               the `helm install <RELEASE_NAME>` command. You can
+                               see the <RELEASE_NAME> by using the `helm list`
+                               command. Required when --pod-discovery-mode is
+                               helm-release.
       --tls                  Whether wire encryption (TLS) between scalar-admin
                                and the target is enabled.
   -w, --max-pause-wait-time=<maxPauseWaitTime>
@@ -51,6 +67,35 @@ Scalar Admin pause tool for the Kubernetes environment
   -z, --time-zone=<zoneId>   Specify a time zone ID, e.g., Asia/Tokyo, to
                                output successful paused period. Note the time
                                zone ID is case sensitive. Etc/UTC by default.
+```
+
+### Usage Examples
+
+**Using Helm release name (default mode):**
+```bash
+scalar-admin-for-kubernetes-cli \
+  --release-name my-scalardb-cluster \
+  --namespace default \
+  --pause-duration 5000
+```
+
+**Using Helm release name with explicit pod discovery mode:**
+```bash
+scalar-admin-for-kubernetes-cli \
+  --pod-discovery-mode helm-release \
+  --release-name my-scalardb-cluster \
+  --namespace default \
+  --pause-duration 5000
+```
+
+**Using Deployment name (Helm-free mode):**
+```bash
+scalar-admin-for-kubernetes-cli \
+  --pod-discovery-mode deployment \
+  --deployment-name scalardb-cluster-node \
+  --admin-port 60053 \
+  --namespace default \
+  --pause-duration 5000
 ```
 
 ## Run the CLI tool in a Kubernetes environment
@@ -102,7 +147,7 @@ The `scalar-admin-for-kubernetes` CLI tool executes Kubernetes APIs in its inter
 
 1. Mount the `ServiceAccount` resource on the `scalar-admin-for-kubernetes` pod, replacing the contents in the angle brackets as described:
 
-   * Pod
+   * Pod (using Helm release name)
 
      ```yaml
      apiVersion: v1
@@ -128,6 +173,42 @@ The `scalar-admin-for-kubernetes` CLI tool executes Kubernetes APIs in its inter
            - -z
            - <TIMEZONE>
      ```
+
+   * Pod (using Deployment name - Helm-free)
+
+     ```yaml
+     apiVersion: v1
+     kind: Pod
+     metadata:
+       name: scalar-admin-for-kubernetes
+       namespace: <YOUR_NAMESPACE>
+     spec:
+       serviceAccountName: scalar-admin-for-kubernetes-sa
+       containers:
+       - name: scalar-admin-for-kubernetes
+         image: ghcr.io/scalar-labs/scalar-admin-for-kubernetes:1.0.0
+         command:
+           - java
+           - -jar
+           - /app.jar
+           - --pod-discovery-mode
+           - deployment
+           - --deployment-name
+           - <DEPLOYMENT_NAME>
+           - --admin-port
+           - <ADMIN_PORT>
+           - -n
+           - <SCALAR_PRODUCT_NAMESPACE>
+           - -d
+           - <PAUSE_DURATION>
+           - -z
+           - <TIMEZONE>
+     ```
+
+     Note: Common admin port values are:
+     - ScalarDB Cluster: 60053
+     - ScalarDL Ledger: 50053
+     - ScalarDL Auditor: 40053
 
 ## Run the CLI tool in a Kubernetes environment by using a Helm Chart
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -7,6 +7,14 @@ dependencies {
    implementation "com.google.inject:guice:${guiceVersion}"
    implementation "info.picocli:picocli:${picocliVersion}"
    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+
+   testImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
+   testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+   testImplementation "org.assertj:assertj-core:${assertjVersion}"
+}
+
+test {
+   useJUnitPlatform()
 }
 
 shadowJar {

--- a/cli/src/main/java/com/scalar/admin/kubernetes/Cli.java
+++ b/cli/src/main/java/com/scalar/admin/kubernetes/Cli.java
@@ -159,8 +159,15 @@ class Cli implements Callable<Integer> {
       // Execute pause operation
       PauseDurationDto durationDto = controller.pause(request);
 
-      // Build result
-      result = new Result(namespace, helmReleaseName, durationDto, zoneId);
+      // Build result based on mode
+      result =
+          new Result(
+              namespace,
+              podDiscoveryMode,
+              helmReleaseName,
+              deploymentName,
+              durationDto,
+              zoneId);
       ObjectMapper mapper = new ObjectMapper();
       System.out.println(mapper.writeValueAsString(result));
     } catch (JsonProcessingException e) {

--- a/cli/src/main/java/com/scalar/admin/kubernetes/Cli.java
+++ b/cli/src/main/java/com/scalar/admin/kubernetes/Cli.java
@@ -37,13 +37,37 @@ class Cli implements Callable<Integer> {
   private String namespace;
 
   @Option(
+      names = {"--pod-discovery-mode"},
+      description =
+          "The mode to discover the target pods. Valid values: helm-release, deployment."
+              + " helm-release by default.",
+      defaultValue = "helm-release")
+  private String podDiscoveryMode;
+
+  @Option(
       names = {"--release-name", "-r"},
       description =
-          "Required. The helm release name that you specify when you run the `helm install"
-              + " <RELEASE_NAME>` command. You can see the <RELEASE_NAME> by using the `helm list`"
-              + " command.",
-      required = true)
+          "The helm release name that you specify when you run the `helm install <RELEASE_NAME>`"
+              + " command. You can see the <RELEASE_NAME> by using the `helm list` command."
+              + " Required when --pod-discovery-mode is helm-release.")
+  @Nullable
   private String helmReleaseName;
+
+  @Option(
+      names = {"--deployment-name"},
+      description =
+          "The name of the Kubernetes Deployment for the Scalar product."
+              + " Required when --pod-discovery-mode is deployment.")
+  @Nullable
+  private String deploymentName;
+
+  @Option(
+      names = {"--admin-port"},
+      description =
+          "The port number of the admin interface of the Scalar product."
+              + " Required when --pod-discovery-mode is deployment.")
+  @Nullable
+  private Integer adminPort;
 
   @Option(
       names = {"--pause-duration", "-d"},
@@ -122,7 +146,10 @@ class Cli implements Callable<Integer> {
       PauseRequest request =
           new PauseRequest(
               namespace,
+              podDiscoveryMode,
               helmReleaseName,
+              deploymentName,
+              adminPort,
               pauseDuration,
               maxPauseWaitTime,
               tlsEnabled,

--- a/cli/src/main/java/com/scalar/admin/kubernetes/Result.java
+++ b/cli/src/main/java/com/scalar/admin/kubernetes/Result.java
@@ -1,9 +1,12 @@
 package com.scalar.admin.kubernetes;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.scalar.admin.kubernetes.application.dto.PauseDurationDto;
+
 import java.time.Instant;
 import java.time.ZoneId;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -11,8 +14,18 @@ class Result {
 
   public final String namespace;
 
+  @JsonProperty("pod_discovery_mode")
+  public final String podDiscoveryMode;
+
   @JsonProperty("helm_release_name")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
   public final String helmReleaseName;
+
+  @JsonProperty("deployment_name")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  public final String deploymentName;
 
   @JsonProperty("pause_start_timestamp_ms")
   public final long pauseStartTimestampMs;
@@ -29,9 +42,16 @@ class Result {
   public final String timezone;
 
   Result(
-      String namespace, String helmReleaseName, PauseDurationDto pauseDurationDto, ZoneId zoneId) {
+      String namespace,
+      String podDiscoveryMode,
+      @Nullable String helmReleaseName,
+      @Nullable String deploymentName,
+      PauseDurationDto pauseDurationDto,
+      ZoneId zoneId) {
     this.namespace = namespace;
+    this.podDiscoveryMode = podDiscoveryMode;
     this.helmReleaseName = helmReleaseName;
+    this.deploymentName = deploymentName;
     this.pauseStartTimestampMs = pauseDurationDto.startTimeEpochMilli();
     this.pauseEndTimestampMs = pauseDurationDto.endTimeEpochMilli();
     this.pauseStartDateTime =

--- a/cli/src/test/java/com/scalar/admin/kubernetes/ResultTest.java
+++ b/cli/src/test/java/com/scalar/admin/kubernetes/ResultTest.java
@@ -1,0 +1,123 @@
+package com.scalar.admin.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scalar.admin.kubernetes.application.dto.PauseDurationDto;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ResultTest {
+
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final ZoneId zoneId = ZoneId.of("Asia/Tokyo");
+  private final PauseDurationDto pauseDurationDto = new PauseDurationDto(1000L, 6000L);
+
+  @Nested
+  @DisplayName("Constructor and field values")
+  class ConstructorAndFieldValues {
+
+    @Test
+    @DisplayName("creates Result with helmReleaseName for HELM_RELEASE mode")
+    void createsResultWithHelmReleaseNameForHelmReleaseMode() {
+      // Arrange & Act
+      Result result = new Result("test-ns", "helm-release", "test-release", null, pauseDurationDto, zoneId);
+
+      // Assert
+      assertThat(result.namespace).isEqualTo("test-ns");
+      assertThat(result.podDiscoveryMode).isEqualTo("helm-release");
+      assertThat(result.helmReleaseName).isEqualTo("test-release");
+      assertThat(result.deploymentName).isNull();
+      assertThat(result.pauseStartTimestampMs).isEqualTo(1000L);
+      assertThat(result.pauseEndTimestampMs).isEqualTo(6000L);
+      assertThat(result.timezone).isEqualTo("Asia/Tokyo");
+    }
+
+    @Test
+    @DisplayName("creates Result with deploymentName for DEPLOYMENT mode")
+    void createsResultWithDeploymentNameForDeploymentMode() {
+      // Arrange & Act
+      Result result = new Result("test-ns", "deployment", null, "test-deployment", pauseDurationDto, zoneId);
+
+      // Assert
+      assertThat(result.namespace).isEqualTo("test-ns");
+      assertThat(result.helmReleaseName).isNull();
+      assertThat(result.podDiscoveryMode).isEqualTo("deployment");
+      assertThat(result.deploymentName).isEqualTo("test-deployment");
+      assertThat(result.pauseStartTimestampMs).isEqualTo(1000L);
+      assertThat(result.pauseEndTimestampMs).isEqualTo(6000L);
+      assertThat(result.timezone).isEqualTo("Asia/Tokyo");
+    }
+  }
+
+  @Nested
+  @DisplayName("JSON serialization")
+  class JsonSerialization {
+
+    @Test
+    @DisplayName("serializes to JSON without deployment_name for HELM_RELEASE mode")
+    void serializesToJsonWithoutDeploymentNameForHelmReleaseMode() throws JsonProcessingException {
+      // Arrange
+      Result result = new Result("test-ns", "helm-release", "test-release", null, pauseDurationDto, zoneId);
+
+      // Act
+      String json = mapper.writeValueAsString(result);
+      JsonNode jsonNode = mapper.readTree(json);
+
+      // Assert
+      assertThat(jsonNode.get("namespace").asText()).isEqualTo("test-ns");
+      assertThat(jsonNode.get("pod_discovery_mode").asText()).isEqualTo("helm-release");
+      assertThat(jsonNode.get("helm_release_name").asText()).isEqualTo("test-release");
+      assertThat(jsonNode.has("deployment_name")).isFalse();
+      assertThat(jsonNode.get("pause_start_timestamp_ms").asLong()).isEqualTo(1000L);
+      assertThat(jsonNode.get("pause_end_timestamp_ms").asLong()).isEqualTo(6000L);
+      assertThat(jsonNode.get("timezone").asText()).isEqualTo("Asia/Tokyo");
+    }
+
+    @Test
+    @DisplayName("serializes to JSON without helm_release_name for DEPLOYMENT mode")
+    void serializesToJsonWithoutHelmReleaseNameForDeploymentMode() throws JsonProcessingException {
+      // Arrange
+      Result result = new Result("test-ns", "deployment", null, "test-deployment", pauseDurationDto, zoneId);
+
+      // Act
+      String json = mapper.writeValueAsString(result);
+      JsonNode jsonNode = mapper.readTree(json);
+
+      // Assert
+      assertThat(jsonNode.get("namespace").asText()).isEqualTo("test-ns");
+      assertThat(jsonNode.get("pod_discovery_mode").asText()).isEqualTo("deployment");
+      assertThat(jsonNode.has("helm_release_name")).isFalse();
+      assertThat(jsonNode.get("deployment_name").asText()).isEqualTo("test-deployment");
+      assertThat(jsonNode.get("pause_start_timestamp_ms").asLong()).isEqualTo(1000L);
+      assertThat(jsonNode.get("pause_end_timestamp_ms").asLong()).isEqualTo(6000L);
+      assertThat(jsonNode.get("timezone").asText()).isEqualTo("Asia/Tokyo");
+    }
+
+    @Test
+    @DisplayName("calculates pause_start_date_time correctly with timezone")
+    void calculatesPauseStartDateTimeCorrectlyWithTimezone() {
+      // Arrange
+      Result result = new Result("test-ns", "helm-release", "test-release", null, pauseDurationDto, zoneId);
+
+      // Assert
+      // 1970-01-01 00:00:01.000 UTC = 1970-01-01 09:00:01 Asia/Tokyo (UTC+9)
+      assertThat(result.pauseStartDateTime).isEqualTo("1970-01-01T09:00:01");
+    }
+
+    @Test
+    @DisplayName("calculates pause_end_date_time correctly with timezone")
+    void calculatesPauseEndDateTimeCorrectlyWithTimezone() {
+      // Arrange
+      Result result = new Result("test-ns", "helm-release", "test-release", null, pauseDurationDto, zoneId);
+
+      // Assert
+      // 1970-01-01 00:00:06.000 UTC = 1970-01-01 09:00:06 Asia/Tokyo (UTC+9)
+      assertThat(result.pauseEndDateTime).isEqualTo("1970-01-01T09:00:06");
+    }
+  }
+}

--- a/lib/src/main/java/com/scalar/admin/kubernetes/application/PauseApplicationService.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/application/PauseApplicationService.java
@@ -3,6 +3,7 @@ package com.scalar.admin.kubernetes.application;
 import com.scalar.admin.kubernetes.application.dto.PauseDurationDto;
 import com.scalar.admin.kubernetes.domain.client.ScalarAdminClient;
 import com.scalar.admin.kubernetes.domain.exception.PauserException;
+import com.scalar.admin.kubernetes.domain.model.pause.PauseByDeploymentNameCommand;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseByHelmReleaseCommand;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseCommand;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseDuration;
@@ -69,6 +70,8 @@ public class PauseApplicationService {
   public PauseDurationDto execute(PauseCommand command) throws PauserException {
     return switch (command) {
       case PauseByHelmReleaseCommand cmd -> executePauseByHelmRelease(cmd);
+      case PauseByDeploymentNameCommand cmd -> throw new UnsupportedOperationException(
+          "DEPLOYMENT mode is not yet implemented. Only HELM_RELEASE mode is currently supported.");
     };
   }
 

--- a/lib/src/main/java/com/scalar/admin/kubernetes/application/PauseApplicationService.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/application/PauseApplicationService.java
@@ -8,9 +8,12 @@ import com.scalar.admin.kubernetes.domain.model.pause.PauseByHelmReleaseCommand;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseCommand;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseDuration;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseTarget;
+import com.scalar.admin.kubernetes.domain.model.pause.TlsConfig;
 import com.scalar.admin.kubernetes.domain.client.KubernetesClient;
 import com.scalar.admin.kubernetes.domain.service.PauseService;
 import com.scalar.admin.kubernetes.domain.client.ScalarAdminClientFactory;
+import com.scalar.admin.kubernetes.domain.service.PauseService.PauseTargetSupplier;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.inject.Inject;
 
@@ -66,27 +69,70 @@ public class PauseApplicationService {
    * @param command the pause command specifying the operation details
    * @return DTO containing the start and end time of the pause operation
    * @throws PauserException when the pause operation fails
+   * @throws IllegalArgumentException when the command is null
    */
   public PauseDurationDto execute(PauseCommand command) throws PauserException {
+    if (command == null) {
+      throw new IllegalArgumentException("command is required");
+    }
     return switch (command) {
       case PauseByHelmReleaseCommand cmd -> executePauseByHelmRelease(cmd);
-      case PauseByDeploymentNameCommand cmd -> throw new UnsupportedOperationException(
-          "DEPLOYMENT mode is not yet implemented. Only HELM_RELEASE mode is currently supported.");
+      case PauseByDeploymentNameCommand cmd -> executePauseByDeploymentName(cmd);
     };
   }
 
   private PauseDurationDto executePauseByHelmRelease(PauseByHelmReleaseCommand command)
       throws PauserException {
+    return executePause(
+        () ->
+            kubernetesClient.resolvePauseTargetByHelmRelease(
+                command.namespace(), command.helmReleaseName()),
+        command.tlsConfig(),
+        command.pauseDuration(),
+        command.maxPauseWaitTime());
+  }
+
+  private PauseDurationDto executePauseByDeploymentName(PauseByDeploymentNameCommand command)
+      throws PauserException {
+    return executePause(
+        () ->
+            kubernetesClient.resolvePauseTargetByDeploymentName(
+                command.namespace(), command.deploymentName(), command.adminPort()),
+        command.tlsConfig(),
+        command.pauseDuration(),
+        command.maxPauseWaitTime());
+  }
+
+  /**
+   * Executes a pause operation with the given target supplier and configuration.
+   *
+   * @param targetSupplier supplier function to retrieve the pause target
+   * @param tlsConfig TLS configuration (null for non-TLS)
+   * @param pauseDuration the duration to pause in milliseconds
+   * @param maxPauseWaitTime the maximum wait time for pause operation (null for default)
+   * @return DTO containing the start and end time of the pause operation
+   * @throws PauserException when the pause operation fails
+   */
+  private PauseDurationDto executePause(
+      PauseTargetSupplier targetSupplier,
+      @Nullable TlsConfig tlsConfig,
+      int pauseDuration,
+      @Nullable Long maxPauseWaitTime)
+      throws PauserException {
+
     // Get the pause target before pause
-    PauseTarget targetBeforePause =
-        kubernetesClient.resolvePauseTargetByHelmRelease(
-            command.namespace(), command.helmReleaseName());
+    PauseTarget targetBeforePause;
+    try {
+      targetBeforePause = targetSupplier.get();
+    } catch (Exception e) {
+      throw new PauserException("Failed to find the target pods to pause.", e);
+    }
 
     // Create the appropriate client (with or without TLS)
     ScalarAdminClient client;
     try {
-      if (command.tlsConfig() != null) {
-        client = clientFactory.createClient(targetBeforePause, command.tlsConfig());
+      if (tlsConfig != null) {
+        client = clientFactory.createClient(targetBeforePause, tlsConfig);
       } else {
         client = clientFactory.createClient(targetBeforePause);
       }
@@ -95,18 +141,12 @@ public class PauseApplicationService {
     }
 
     // Execute the pause operation through the domain service
-    PauseDuration pauseDuration =
+    PauseDuration duration =
         pauseService.pause(
-            targetBeforePause,
-            () ->
-                kubernetesClient.resolvePauseTargetByHelmRelease(
-                    command.namespace(), command.helmReleaseName()),
-            client,
-            command.pauseDuration(),
-            command.maxPauseWaitTime());
+            targetBeforePause, targetSupplier, client, pauseDuration, maxPauseWaitTime);
 
     // Convert domain object to DTO
     return new PauseDurationDto(
-        pauseDuration.startTime().toEpochMilli(), pauseDuration.endTime().toEpochMilli());
+        duration.startTime().toEpochMilli(), duration.endTime().toEpochMilli());
   }
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/application/PauseApplicationService.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/application/PauseApplicationService.java
@@ -124,6 +124,8 @@ public class PauseApplicationService {
     PauseTarget targetBeforePause;
     try {
       targetBeforePause = targetSupplier.get();
+    } catch (PauserException e) {
+      throw e;
     } catch (Exception e) {
       throw new PauserException("Failed to find the target pods to pause.", e);
     }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/client/KubernetesClient.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/client/KubernetesClient.java
@@ -26,4 +26,21 @@ public interface KubernetesClient {
    */
   PauseTarget resolvePauseTargetByHelmRelease(String namespace, String helmReleaseName)
       throws PauserException;
+
+  /**
+   * Resolves a pause target by deployment name in the specified namespace.
+   *
+   * <p>This method discovers pods that belong to the specified deployment and constructs a {@link
+   * PauseTarget} aggregate. Unlike the Helm release-based discovery, this method requires an
+   * explicit admin port since it cannot be auto-detected from deployment labels.
+   *
+   * @param namespace the Kubernetes namespace where the deployment exists
+   * @param deploymentName the name of the deployment
+   * @param adminPort the admin port number for the Scalar product
+   * @return a PauseTarget aggregate containing pods, deployment, and admin port information
+   * @throws PauserException if the target cannot be resolved or if there are issues with the
+   *     Kubernetes API
+   */
+  PauseTarget resolvePauseTargetByDeploymentName(String namespace, String deploymentName, int adminPort)
+      throws PauserException;
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommand.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommand.java
@@ -39,18 +39,16 @@ public record PauseByDeploymentNameCommand(
    */
   public PauseByDeploymentNameCommand {
     if (namespace == null || namespace.isBlank()) {
-      throw new IllegalArgumentException("namespace is required");
+      throw new IllegalArgumentException(NAMESPACE_REQUIRED_ERROR);
     }
     if (deploymentName == null || deploymentName.isBlank()) {
-      throw new IllegalArgumentException("deploymentName is required");
+      throw new IllegalArgumentException(DEPLOYMENT_NAME_REQUIRED_ERROR);
     }
     if (adminPort < 1 || adminPort > 65535) {
-      throw new IllegalArgumentException(
-          "adminPort must be between 1 and 65535, but was: " + adminPort);
+      throw new IllegalArgumentException(String.format(ADMIN_PORT_ERROR, adminPort));
     }
     if (pauseDuration < 1) {
-      throw new IllegalArgumentException(
-          "pauseDuration must be greater than 0 millisecond, but was: " + pauseDuration);
+      throw new IllegalArgumentException(String.format(PAUSE_DURATION_ERROR, pauseDuration));
     }
   }
 

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommand.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommand.java
@@ -1,0 +1,115 @@
+package com.scalar.admin.kubernetes.domain.model.pause;
+
+import javax.annotation.Nullable;
+
+/**
+ * Command to pause pods identified by deployment name.
+ *
+ * <p>This command represents the use case of pausing all pods that belong to a specific deployment
+ * in a given namespace. The admin port must be explicitly specified as it cannot be auto-detected
+ * from deployment labels.
+ *
+ * @param namespace the Kubernetes namespace where the deployment exists
+ * @param deploymentName the name of the deployment
+ * @param adminPort the admin port number for the Scalar product
+ * @param pauseDuration the duration to pause in milliseconds
+ * @param maxPauseWaitTime the maximum wait time (in milliseconds) for pause operation to complete,
+ *     null for default
+ * @param tlsConfig the TLS configuration for secure communication, null for non-TLS communication
+ */
+public record PauseByDeploymentNameCommand(
+    String namespace,
+    String deploymentName,
+    int adminPort,
+    int pauseDuration,
+    @Nullable Long maxPauseWaitTime,
+    @Nullable TlsConfig tlsConfig)
+    implements PauseCommand {
+
+  /**
+   * Compact constructor with validation.
+   *
+   * @param namespace the Kubernetes namespace (required)
+   * @param deploymentName the deployment name (required)
+   * @param adminPort the admin port number (must be 0-65535)
+   * @param pauseDuration the pause duration in milliseconds (must be positive)
+   * @param maxPauseWaitTime the maximum wait time (optional)
+   * @param tlsConfig the TLS configuration (optional)
+   * @throws IllegalArgumentException if required parameters are null or invalid
+   */
+  public PauseByDeploymentNameCommand {
+    if (namespace == null || namespace.isBlank()) {
+      throw new IllegalArgumentException("namespace is required");
+    }
+    if (deploymentName == null || deploymentName.isBlank()) {
+      throw new IllegalArgumentException("deploymentName is required");
+    }
+    if (adminPort < 0 || adminPort > 65535) {
+      throw new IllegalArgumentException(
+          "adminPort must be between 0 and 65535, but was: " + adminPort);
+    }
+    if (pauseDuration < 1) {
+      throw new IllegalArgumentException(
+          "pauseDuration must be greater than 0 millisecond, but was: " + pauseDuration);
+    }
+  }
+
+  /**
+   * Creates a command for pausing pods without TLS.
+   *
+   * @param namespace the Kubernetes namespace
+   * @param deploymentName the deployment name
+   * @param adminPort the admin port number
+   * @param pauseDuration the pause duration in milliseconds
+   * @param maxPauseWaitTime the maximum wait time in milliseconds
+   * @return a new PauseByDeploymentNameCommand without TLS
+   */
+  public static PauseByDeploymentNameCommand create(
+      String namespace,
+      String deploymentName,
+      int adminPort,
+      int pauseDuration,
+      Long maxPauseWaitTime) {
+    return new PauseByDeploymentNameCommand(
+        namespace, deploymentName, adminPort, pauseDuration, maxPauseWaitTime, null);
+  }
+
+  /**
+   * Creates a command for pausing pods with TLS enabled.
+   *
+   * @param namespace the Kubernetes namespace
+   * @param deploymentName the deployment name
+   * @param adminPort the admin port number
+   * @param pauseDuration the pause duration in milliseconds
+   * @param maxPauseWaitTime the maximum wait time in milliseconds
+   * @param caRootCert the CA root certificate
+   * @param overrideAuthority the override authority for TLS
+   * @return a new PauseByDeploymentNameCommand with TLS configuration
+   */
+  public static PauseByDeploymentNameCommand createWithTls(
+      String namespace,
+      String deploymentName,
+      int adminPort,
+      int pauseDuration,
+      Long maxPauseWaitTime,
+      String caRootCert,
+      String overrideAuthority) {
+    return new PauseByDeploymentNameCommand(
+        namespace,
+        deploymentName,
+        adminPort,
+        pauseDuration,
+        maxPauseWaitTime,
+        new TlsConfig(caRootCert, overrideAuthority));
+  }
+
+  /**
+   * Returns the pod discovery mode for this command.
+   *
+   * @return DEPLOYMENT mode
+   */
+  @Override
+  public PodDiscoveryMode podDiscoveryMode() {
+    return PodDiscoveryMode.DEPLOYMENT;
+  }
+}

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommand.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommand.java
@@ -31,7 +31,7 @@ public record PauseByDeploymentNameCommand(
    *
    * @param namespace the Kubernetes namespace (required)
    * @param deploymentName the deployment name (required)
-   * @param adminPort the admin port number (must be 0-65535)
+   * @param adminPort the admin port number (must be 1-65535)
    * @param pauseDuration the pause duration in milliseconds (must be positive)
    * @param maxPauseWaitTime the maximum wait time (optional)
    * @param tlsConfig the TLS configuration (optional)
@@ -44,9 +44,9 @@ public record PauseByDeploymentNameCommand(
     if (deploymentName == null || deploymentName.isBlank()) {
       throw new IllegalArgumentException("deploymentName is required");
     }
-    if (adminPort < 0 || adminPort > 65535) {
+    if (adminPort < 1 || adminPort > 65535) {
       throw new IllegalArgumentException(
-          "adminPort must be between 0 and 65535, but was: " + adminPort);
+          "adminPort must be between 1 and 65535, but was: " + adminPort);
     }
     if (pauseDuration < 1) {
       throw new IllegalArgumentException(

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByHelmReleaseCommand.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByHelmReleaseCommand.java
@@ -36,14 +36,13 @@ public record PauseByHelmReleaseCommand(
    */
   public PauseByHelmReleaseCommand {
     if (namespace == null || namespace.isBlank()) {
-      throw new IllegalArgumentException("namespace is required");
+      throw new IllegalArgumentException(NAMESPACE_REQUIRED_ERROR);
     }
     if (helmReleaseName == null || helmReleaseName.isBlank()) {
-      throw new IllegalArgumentException("helmReleaseName is required");
+      throw new IllegalArgumentException(HELM_RELEASE_NAME_REQUIRED_ERROR);
     }
     if (pauseDuration < 1) {
-      throw new IllegalArgumentException(
-          "pauseDuration must be greater than 0 millisecond, but was: " + pauseDuration);
+      throw new IllegalArgumentException(String.format(PAUSE_DURATION_ERROR, pauseDuration));
     }
   }
 

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByHelmReleaseCommand.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByHelmReleaseCommand.java
@@ -87,4 +87,14 @@ public record PauseByHelmReleaseCommand(
         maxPauseWaitTime,
         new TlsConfig(caRootCert, overrideAuthority));
   }
+
+  /**
+   * Returns the pod discovery mode for this command.
+   *
+   * @return HELM_RELEASE mode
+   */
+  @Override
+  public PodDiscoveryMode podDiscoveryMode() {
+    return PodDiscoveryMode.HELM_RELEASE;
+  }
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseCommand.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseCommand.java
@@ -13,4 +13,16 @@ public sealed interface PauseCommand permits PauseByHelmReleaseCommand {
   // Future implementations might include:
   // - PauseByDeploymentCommand
   // - PauseByLabelSelectorCommand
+
+  /**
+   * Returns the pod discovery mode for this command.
+   *
+   * <p>This method specifies how the system should identify target pods. The default
+   * implementation returns HELM_RELEASE for backward compatibility.
+   *
+   * @return the pod discovery mode
+   */
+  default PodDiscoveryMode podDiscoveryMode() {
+    return PodDiscoveryMode.HELM_RELEASE;
+  }
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseCommand.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseCommand.java
@@ -12,6 +12,13 @@ package com.scalar.admin.kubernetes.domain.model.pause;
 public sealed interface PauseCommand
     permits PauseByHelmReleaseCommand, PauseByDeploymentNameCommand {
 
+  /** Shared validation error messages for Command compact constructors. */
+  String NAMESPACE_REQUIRED_ERROR = "namespace is required";
+  String HELM_RELEASE_NAME_REQUIRED_ERROR = "helmReleaseName is required";
+  String DEPLOYMENT_NAME_REQUIRED_ERROR = "deploymentName is required";
+  String PAUSE_DURATION_ERROR = "pauseDuration must be greater than 0 millisecond, but was: %d";
+  String ADMIN_PORT_ERROR = "adminPort must be between 1 and 65535, but was: %d";
+
   /**
    * Returns the pod discovery mode for this command.
    *

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseCommand.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseCommand.java
@@ -9,10 +9,8 @@ package com.scalar.admin.kubernetes.domain.model.pause;
  * <p>Each implementation represents a specific way to identify and pause target pods in a
  * Kubernetes cluster.
  */
-public sealed interface PauseCommand permits PauseByHelmReleaseCommand {
-  // Future implementations might include:
-  // - PauseByDeploymentCommand
-  // - PauseByLabelSelectorCommand
+public sealed interface PauseCommand
+    permits PauseByHelmReleaseCommand, PauseByDeploymentNameCommand {
 
   /**
    * Returns the pod discovery mode for this command.

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseCommand.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseCommand.java
@@ -22,12 +22,9 @@ public sealed interface PauseCommand
   /**
    * Returns the pod discovery mode for this command.
    *
-   * <p>This method specifies how the system should identify target pods. The default
-   * implementation returns HELM_RELEASE for backward compatibility.
+   * <p>This method specifies how the system should identify target pods.
    *
    * @return the pod discovery mode
    */
-  default PodDiscoveryMode podDiscoveryMode() {
-    return PodDiscoveryMode.HELM_RELEASE;
-  }
+  PodDiscoveryMode podDiscoveryMode();
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseTarget.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseTarget.java
@@ -42,8 +42,9 @@ public record PauseTarget(List<V1Pod> pods, V1Deployment deployment, int adminPo
     if (deployment == null) {
       throw new IllegalArgumentException("deployment must not be null");
     }
-    if (adminPort < 1) {
-      throw new IllegalArgumentException("adminPort must be greater than 0");
+    if (adminPort < 1 || adminPort > 65535) {
+      throw new IllegalArgumentException(
+          String.format(PauseCommand.ADMIN_PORT_ERROR, adminPort));
     }
     pods = ImmutableList.copyOf(pods);
   }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
@@ -72,7 +72,7 @@ public enum PodDiscoveryMode {
    * @param helmReleaseName the Helm release name (required for HELM_RELEASE mode)
    * @param deploymentName the deployment name (required for DEPLOYMENT mode)
    * @param adminPort the admin port (required for DEPLOYMENT mode)
-   * @throws IllegalArgumentException if required parameters are missing or invalid for this mode
+   * @throws IllegalArgumentException if required parameters are missing or disallowed for this mode
    */
   public void validate(
       @Nullable String helmReleaseName,
@@ -98,11 +98,6 @@ public enum PodDiscoveryMode {
         if (adminPort == null) {
           throw new IllegalArgumentException(
               "adminPort is required when podDiscoveryMode is DEPLOYMENT");
-        }
-        if (adminPort < 1 || adminPort > 65535) {
-          throw new IllegalArgumentException(
-              "adminPort must be between 1 and 65535 when podDiscoveryMode is DEPLOYMENT, but was: "
-                  + adminPort);
         }
         if (helmReleaseName != null) {
           throw new IllegalArgumentException(

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
@@ -78,8 +78,8 @@ public enum PodDiscoveryMode {
       @Nullable String helmReleaseName,
       @Nullable String deploymentName,
       @Nullable Integer adminPort) {
-    switch (this) {
-      case HELM_RELEASE:
+    var _exhaustiveCheck = switch (this) {
+      case HELM_RELEASE -> {
         if (helmReleaseName == null || helmReleaseName.isBlank()) {
           throw new IllegalArgumentException(
               "helmReleaseName is required when podDiscoveryMode is HELM_RELEASE");
@@ -88,8 +88,9 @@ public enum PodDiscoveryMode {
           throw new IllegalArgumentException(
               "deploymentName and adminPort cannot be used when podDiscoveryMode is HELM_RELEASE");
         }
-        break;
-      case DEPLOYMENT:
+        yield (Void) null;
+      }
+      case DEPLOYMENT -> {
         if (deploymentName == null || deploymentName.isBlank()) {
           throw new IllegalArgumentException(
               "deploymentName is required when podDiscoveryMode is DEPLOYMENT");
@@ -100,13 +101,15 @@ public enum PodDiscoveryMode {
         }
         if (adminPort < 1 || adminPort > 65535) {
           throw new IllegalArgumentException(
-              "adminPort must be between 1 and 65535 when podDiscoveryMode is DEPLOYMENT, but was: " + adminPort);
+              "adminPort must be between 1 and 65535 when podDiscoveryMode is DEPLOYMENT, but was: "
+                  + adminPort);
         }
         if (helmReleaseName != null) {
           throw new IllegalArgumentException(
               "helmReleaseName cannot be used when podDiscoveryMode is DEPLOYMENT");
         }
-        break;
-    }
+        yield (Void) null;
+      }
+    };
   }
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
@@ -1,0 +1,76 @@
+package com.scalar.admin.kubernetes.domain.model.pause;
+
+import javax.annotation.Nullable;
+
+/**
+ * Enum representing the mode for discovering target pods to pause.
+ *
+ * <p>This enum defines how the system identifies which pods should be paused. Different modes
+ * provide different strategies for pod discovery in a Kubernetes cluster.
+ */
+public enum PodDiscoveryMode {
+  /**
+   * Discover pods by Helm release name.
+   *
+   * <p>In this mode, the system identifies pods by looking for resources labeled with the
+   * specified Helm release name. This is the default and original behavior.
+   */
+  HELM_RELEASE("helm-release");
+
+  private final String value;
+
+  PodDiscoveryMode(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Returns the string value of this mode.
+   *
+   * @return the string value (e.g., "helm-release")
+   */
+  public String getValue() {
+    return value;
+  }
+
+  /**
+   * Converts a string value to PodDiscoveryMode enum.
+   *
+   * <p>This method uses case-insensitive matching for better user experience, consistent with
+   * picocli's setCaseInsensitiveEnumValuesAllowed(true) setting used in the CLI layer.
+   *
+   * @param value the string value (case-insensitive)
+   * @return the corresponding PodDiscoveryMode
+   * @throws IllegalArgumentException if the value is invalid
+   */
+  public static PodDiscoveryMode fromValue(String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException("podDiscoveryMode value cannot be null or blank");
+    }
+
+    // Case-insensitive comparison for consistency with CLI's setCaseInsensitiveEnumValuesAllowed
+    for (PodDiscoveryMode mode : values()) {
+      if (mode.value.equalsIgnoreCase(value)) {
+        return mode;
+      }
+    }
+
+    throw new IllegalArgumentException(
+        "Invalid podDiscoveryMode: " + value + ". Valid values are: helm-release");
+  }
+
+  /**
+   * Validates the required parameters for this discovery mode.
+   *
+   * <p>Phase 1: Only validates helmReleaseName (deploymentName and adminPort don't exist yet).
+   *
+   * @param helmReleaseName the Helm release name (required for HELM_RELEASE mode)
+   * @throws IllegalArgumentException if required parameters are missing or invalid for this mode
+   */
+  public void validate(@Nullable String helmReleaseName) {
+    // Phase 1: Only HELM_RELEASE exists
+    if (helmReleaseName == null || helmReleaseName.isBlank()) {
+      throw new IllegalArgumentException(
+          "helmReleaseName is required when podDiscoveryMode is HELM_RELEASE");
+    }
+  }
+}

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
@@ -15,7 +15,15 @@ public enum PodDiscoveryMode {
    * <p>In this mode, the system identifies pods by looking for resources labeled with the
    * specified Helm release name. This is the default and original behavior.
    */
-  HELM_RELEASE("helm-release");
+  HELM_RELEASE("helm-release"),
+
+  /**
+   * Discover pods by deployment name.
+   *
+   * <p>In this mode, the system identifies pods by the deployment name. The admin port must be
+   * explicitly specified as it cannot be auto-detected.
+   */
+  DEPLOYMENT("deployment");
 
   private final String value;
 
@@ -26,7 +34,7 @@ public enum PodDiscoveryMode {
   /**
    * Returns the string value of this mode.
    *
-   * @return the string value (e.g., "helm-release")
+   * @return the string value (e.g., "helm-release", "deployment")
    */
   public String getValue() {
     return value;
@@ -55,22 +63,46 @@ public enum PodDiscoveryMode {
     }
 
     throw new IllegalArgumentException(
-        "Invalid podDiscoveryMode: " + value + ". Valid values are: helm-release");
+        "Invalid podDiscoveryMode: " + value + ". Valid values are: helm-release, deployment");
   }
 
   /**
    * Validates the required parameters for this discovery mode.
    *
-   * <p>Phase 1: Only validates helmReleaseName (deploymentName and adminPort don't exist yet).
-   *
    * @param helmReleaseName the Helm release name (required for HELM_RELEASE mode)
+   * @param deploymentName the deployment name (required for DEPLOYMENT mode)
+   * @param adminPort the admin port (required for DEPLOYMENT mode)
    * @throws IllegalArgumentException if required parameters are missing or invalid for this mode
    */
-  public void validate(@Nullable String helmReleaseName) {
-    // Phase 1: Only HELM_RELEASE exists
-    if (helmReleaseName == null || helmReleaseName.isBlank()) {
-      throw new IllegalArgumentException(
-          "helmReleaseName is required when podDiscoveryMode is HELM_RELEASE");
+  public void validate(
+      @Nullable String helmReleaseName,
+      @Nullable String deploymentName,
+      @Nullable Integer adminPort) {
+    switch (this) {
+      case HELM_RELEASE:
+        if (helmReleaseName == null || helmReleaseName.isBlank()) {
+          throw new IllegalArgumentException(
+              "helmReleaseName is required when podDiscoveryMode is HELM_RELEASE");
+        }
+        if (deploymentName != null || adminPort != null) {
+          throw new IllegalArgumentException(
+              "deploymentName and adminPort cannot be used when podDiscoveryMode is HELM_RELEASE");
+        }
+        break;
+      case DEPLOYMENT:
+        if (deploymentName == null || deploymentName.isBlank()) {
+          throw new IllegalArgumentException(
+              "deploymentName is required when podDiscoveryMode is DEPLOYMENT");
+        }
+        if (adminPort == null) {
+          throw new IllegalArgumentException(
+              "adminPort is required when podDiscoveryMode is DEPLOYMENT");
+        }
+        if (helmReleaseName != null) {
+          throw new IllegalArgumentException(
+              "helmReleaseName cannot be used when podDiscoveryMode is DEPLOYMENT");
+        }
+        break;
     }
   }
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java
@@ -98,6 +98,10 @@ public enum PodDiscoveryMode {
           throw new IllegalArgumentException(
               "adminPort is required when podDiscoveryMode is DEPLOYMENT");
         }
+        if (adminPort < 1 || adminPort > 65535) {
+          throw new IllegalArgumentException(
+              "adminPort must be between 1 and 65535 when podDiscoveryMode is DEPLOYMENT, but was: " + adminPort);
+        }
         if (helmReleaseName != null) {
           throw new IllegalArgumentException(
               "helmReleaseName cannot be used when podDiscoveryMode is DEPLOYMENT");

--- a/lib/src/main/java/com/scalar/admin/kubernetes/domain/service/PauseService.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/domain/service/PauseService.java
@@ -89,10 +89,6 @@ public class PauseService {
     Objects.requireNonNull(targetBeforePause, "targetBeforePause is required");
     Objects.requireNonNull(targetAfterPauseSupplier, "targetAfterPauseSupplier is required");
     Objects.requireNonNull(client, "client is required");
-    if (pauseDuration < 1) {
-      throw new IllegalArgumentException(
-          "pauseDuration is required to be greater than 0 millisecond.");
-    }
 
     // From here, we cannot throw exceptions right after they occur because we need to take care of
     // the unpause operation failure. We will throw the exception after the unpause operation or at

--- a/lib/src/main/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImpl.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImpl.java
@@ -86,6 +86,13 @@ public class KubernetesClientImpl implements KubernetesClient {
   }
 
   String extractLabelSelectorFromDeployment(V1Deployment deployment) throws PauserException {
+    // V1Deployment.getMetadata() is @Nullable per the Kubernetes Java client API,
+    // but in practice it is never null for objects returned by the Kubernetes API.
+    // A future refactoring will introduce domain models to eliminate these SDK types.
+    // See: https://github.com/scalar-labs/scalar-admin-for-kubernetes/pull/46#discussion_r3393957290
+    if (deployment.getMetadata() == null) {
+      throw new PauserException("Deployment has no metadata. This should not happen.");
+    }
     String deploymentName = deployment.getMetadata().getName();
     String namespace = deployment.getMetadata().getNamespace();
 

--- a/lib/src/main/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImpl.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImpl.java
@@ -9,11 +9,13 @@ import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1DeploymentList;
+import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1Service;
 import io.kubernetes.client.openapi.models.V1ServiceList;
 import io.kubernetes.client.openapi.models.V1ServicePort;
+import io.kubernetes.client.util.labels.LabelSelector;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +62,103 @@ public class KubernetesClientImpl implements KubernetesClient {
     } catch (Exception e) {
       throw new PauserException("Can not find any target pods.", e);
     }
+  }
+
+  @Override
+  public PauseTarget resolvePauseTargetByDeploymentName(String namespace, String deploymentName, int adminPort)
+      throws PauserException {
+    V1Deployment deployment = getDeployment(namespace, deploymentName);
+    String labelSelector = extractLabelSelectorFromDeployment(deployment);
+    List<V1Pod> pods = findPodsByLabelSelector(namespace, deploymentName, labelSelector);
+    return new PauseTarget(pods, deployment, adminPort);
+  }
+
+  V1Deployment getDeployment(String namespace, String deploymentName) throws PauserException {
+    try {
+      return appsApi.readNamespacedDeployment(deploymentName, namespace, null);
+    } catch (ApiException e) {
+      String m =
+          String.format(
+              "Kubernetes readNamespacedDeployment API error with code %d and body %s.",
+              e.getCode(), e.getResponseBody());
+      throw new PauserException(m, e);
+    }
+  }
+
+  String extractLabelSelectorFromDeployment(V1Deployment deployment) throws PauserException {
+    String deploymentName = deployment.getMetadata().getName();
+    String namespace = deployment.getMetadata().getNamespace();
+
+    // Check if deployment has a spec
+    if (deployment.getSpec() == null) {
+      String m =
+          String.format(
+              "Deployment %s in namespace %s does not have a spec.", deploymentName, namespace);
+      throw new PauserException(m);
+    }
+
+    // Note: selector is a required field in Kubernetes Deployment spec (since v1.16).
+    // It should never be null for a valid Deployment, but we check defensively in case
+    // of API errors, data corruption, or unexpected responses.
+    V1LabelSelector selector = deployment.getSpec().getSelector();
+    if (selector == null) {
+      String m =
+          String.format(
+              "Deployment %s in namespace %s does not have a selector.",
+              deploymentName, namespace);
+      throw new PauserException(m);
+    }
+
+    // Parse selector (may throw IllegalArgumentException for invalid operators)
+    String labelSelector;
+    try {
+      labelSelector = LabelSelector.parse(selector).toString();
+    } catch (IllegalArgumentException e) {
+      String m =
+          String.format(
+              "Deployment %s in namespace %s has an invalid selector.",
+              deploymentName, namespace);
+      throw new PauserException(m, e);
+    }
+
+    // Check if label selector is empty
+    if (labelSelector.isEmpty()) {
+      String m =
+          String.format(
+              "Deployment %s in namespace %s has an empty selector.",
+              deploymentName, namespace);
+      throw new PauserException(m);
+    }
+
+    return labelSelector;
+  }
+
+  List<V1Pod> findPodsByLabelSelector(
+      String namespace, String deploymentName, String labelSelector) throws PauserException {
+    V1PodList podList;
+    try {
+      podList =
+          coreApi.listNamespacedPod(
+              namespace, null, null, null, null, labelSelector, null, null, null, null, null);
+    } catch (ApiException e) {
+      String m =
+          String.format(
+              "Kubernetes listNamespacedPod API error with code %d and body %s.",
+              e.getCode(), e.getResponseBody());
+      throw new PauserException(m, e);
+    }
+
+    List<V1Pod> pods = podList.getItems();
+
+    if (pods.isEmpty()) {
+      String m =
+          String.format(
+              "Deployment %s in namespace %s does not have any running pods.",
+              deploymentName, namespace);
+      throw new PauserException(m);
+    }
+
+    return pods;
   }
 
   private List<V1Pod> findPodsCreatedByHelmRelease(String namespace, String releaseName)

--- a/lib/src/main/java/com/scalar/admin/kubernetes/presentation/PauseController.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/presentation/PauseController.java
@@ -4,6 +4,7 @@ import com.scalar.admin.kubernetes.application.PauseApplicationService;
 import com.scalar.admin.kubernetes.application.dto.PauseDurationDto;
 import com.scalar.admin.kubernetes.domain.exception.PauserException;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseByHelmReleaseCommand;
+import com.scalar.admin.kubernetes.domain.model.pause.PodDiscoveryMode;
 import com.scalar.admin.kubernetes.presentation.dto.PauseRequest;
 import javax.inject.Inject;
 
@@ -36,11 +37,21 @@ public class PauseController {
    * @param request the pause request containing all necessary parameters
    * @return DTO containing the start and end time of the pause operation
    * @throws PauserException when the pause operation fails
-   * @throws IllegalArgumentException when the request is null
+   * @throws IllegalArgumentException when the request or podDiscoveryMode is invalid
+   * @throws UnsupportedOperationException when DEPLOYMENT mode is requested (not yet implemented)
    */
   public PauseDurationDto pause(PauseRequest request) throws PauserException {
     if (request == null) {
       throw new IllegalArgumentException("request is required");
+    }
+
+    PodDiscoveryMode mode = PodDiscoveryMode.fromValue(request.podDiscoveryMode());
+    mode.validate(request.helmReleaseName(), request.deploymentName(), request.adminPort());
+
+    if (mode == PodDiscoveryMode.DEPLOYMENT) {
+      throw new UnsupportedOperationException(
+          "DEPLOYMENT mode is not yet implemented. Only HELM_RELEASE mode is currently"
+              + " supported.");
     }
 
     PauseByHelmReleaseCommand command =

--- a/lib/src/main/java/com/scalar/admin/kubernetes/presentation/PauseController.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/presentation/PauseController.java
@@ -3,7 +3,9 @@ package com.scalar.admin.kubernetes.presentation;
 import com.scalar.admin.kubernetes.application.PauseApplicationService;
 import com.scalar.admin.kubernetes.application.dto.PauseDurationDto;
 import com.scalar.admin.kubernetes.domain.exception.PauserException;
+import com.scalar.admin.kubernetes.domain.model.pause.PauseByDeploymentNameCommand;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseByHelmReleaseCommand;
+import com.scalar.admin.kubernetes.domain.model.pause.PauseCommand;
 import com.scalar.admin.kubernetes.domain.model.pause.PodDiscoveryMode;
 import com.scalar.admin.kubernetes.presentation.dto.PauseRequest;
 import javax.inject.Inject;
@@ -38,7 +40,6 @@ public class PauseController {
    * @return DTO containing the start and end time of the pause operation
    * @throws PauserException when the pause operation fails
    * @throws IllegalArgumentException when the request or podDiscoveryMode is invalid
-   * @throws UnsupportedOperationException when DEPLOYMENT mode is requested (not yet implemented)
    */
   public PauseDurationDto pause(PauseRequest request) throws PauserException {
     if (request == null) {
@@ -48,27 +49,49 @@ public class PauseController {
     PodDiscoveryMode mode = PodDiscoveryMode.fromValue(request.podDiscoveryMode());
     mode.validate(request.helmReleaseName(), request.deploymentName(), request.adminPort());
 
-    if (mode == PodDiscoveryMode.DEPLOYMENT) {
-      throw new UnsupportedOperationException(
-          "DEPLOYMENT mode is not yet implemented. Only HELM_RELEASE mode is currently"
-              + " supported.");
-    }
-
-    PauseByHelmReleaseCommand command =
-        request.tlsEnabled()
-            ? PauseByHelmReleaseCommand.createWithTls(
-                request.namespace(),
-                request.helmReleaseName(),
-                request.pauseDuration(),
-                request.maxPauseWaitTime(),
-                request.caRootCert(),
-                request.overrideAuthority())
-            : PauseByHelmReleaseCommand.create(
-                request.namespace(),
-                request.helmReleaseName(),
-                request.pauseDuration(),
-                request.maxPauseWaitTime());
+    PauseCommand command = createCommand(request, mode);
 
     return applicationService.execute(command);
+  }
+
+  PauseCommand createCommand(PauseRequest request, PodDiscoveryMode mode) {
+    return switch (mode) {
+      case HELM_RELEASE -> createHelmReleaseCommand(request);
+      case DEPLOYMENT -> createDeploymentCommand(request);
+    };
+  }
+
+  PauseByHelmReleaseCommand createHelmReleaseCommand(PauseRequest request) {
+    return request.tlsEnabled()
+        ? PauseByHelmReleaseCommand.createWithTls(
+            request.namespace(),
+            request.helmReleaseName(),
+            request.pauseDuration(),
+            request.maxPauseWaitTime(),
+            request.caRootCert(),
+            request.overrideAuthority())
+        : PauseByHelmReleaseCommand.create(
+            request.namespace(),
+            request.helmReleaseName(),
+            request.pauseDuration(),
+            request.maxPauseWaitTime());
+  }
+
+  PauseByDeploymentNameCommand createDeploymentCommand(PauseRequest request) {
+    return request.tlsEnabled()
+        ? PauseByDeploymentNameCommand.createWithTls(
+            request.namespace(),
+            request.deploymentName(),
+            request.adminPort(),
+            request.pauseDuration(),
+            request.maxPauseWaitTime(),
+            request.caRootCert(),
+            request.overrideAuthority())
+        : PauseByDeploymentNameCommand.create(
+            request.namespace(),
+            request.deploymentName(),
+            request.adminPort(),
+            request.pauseDuration(),
+            request.maxPauseWaitTime());
   }
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/presentation/PauseController.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/presentation/PauseController.java
@@ -36,9 +36,13 @@ public class PauseController {
    * @param request the pause request containing all necessary parameters
    * @return DTO containing the start and end time of the pause operation
    * @throws PauserException when the pause operation fails
+   * @throws IllegalArgumentException when the request is null
    */
   public PauseDurationDto pause(PauseRequest request) throws PauserException {
-    // Build command from request
+    if (request == null) {
+      throw new IllegalArgumentException("request is required");
+    }
+
     PauseByHelmReleaseCommand command =
         request.tlsEnabled()
             ? PauseByHelmReleaseCommand.createWithTls(
@@ -54,7 +58,6 @@ public class PauseController {
                 request.pauseDuration(),
                 request.maxPauseWaitTime());
 
-    // Execute command
     return applicationService.execute(command);
   }
 }

--- a/lib/src/main/java/com/scalar/admin/kubernetes/presentation/dto/PauseRequest.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/presentation/dto/PauseRequest.java
@@ -44,10 +44,6 @@ public record PauseRequest(
     if (podDiscoveryMode == null || podDiscoveryMode.isBlank()) {
       throw new IllegalArgumentException("podDiscoveryMode is required");
     }
-    if (pauseDuration < 1) {
-      throw new IllegalArgumentException(
-          "pauseDuration must be greater than 0, but was: " + pauseDuration);
-    }
     if (tlsEnabled) {
       if (caRootCert == null || caRootCert.isBlank()) {
         throw new IllegalArgumentException("caRootCert is required when tlsEnabled is true");

--- a/lib/src/main/java/com/scalar/admin/kubernetes/presentation/dto/PauseRequest.java
+++ b/lib/src/main/java/com/scalar/admin/kubernetes/presentation/dto/PauseRequest.java
@@ -9,7 +9,10 @@ import javax.annotation.Nullable;
  * encapsulating all parameters needed for a pause operation.
  *
  * @param namespace the Kubernetes namespace where the target is deployed
- * @param helmReleaseName the name of the Helm release
+ * @param podDiscoveryMode the mode to discover target pods (e.g., "helm-release", "deployment")
+ * @param helmReleaseName the name of the Helm release (required for "helm-release" mode)
+ * @param deploymentName the name of the deployment (required for "deployment" mode)
+ * @param adminPort the admin port number (required for "deployment" mode)
  * @param pauseDuration the duration to pause in milliseconds
  * @param maxPauseWaitTime the maximum wait time in milliseconds for pause operation to complete,
  *     null for default
@@ -19,7 +22,10 @@ import javax.annotation.Nullable;
  */
 public record PauseRequest(
     String namespace,
-    String helmReleaseName,
+    String podDiscoveryMode,
+    @Nullable String helmReleaseName,
+    @Nullable String deploymentName,
+    @Nullable Integer adminPort,
     int pauseDuration,
     @Nullable Long maxPauseWaitTime,
     boolean tlsEnabled,
@@ -35,8 +41,8 @@ public record PauseRequest(
     if (namespace == null || namespace.isBlank()) {
       throw new IllegalArgumentException("namespace is required");
     }
-    if (helmReleaseName == null || helmReleaseName.isBlank()) {
-      throw new IllegalArgumentException("helmReleaseName is required");
+    if (podDiscoveryMode == null || podDiscoveryMode.isBlank()) {
+      throw new IllegalArgumentException("podDiscoveryMode is required");
     }
     if (pauseDuration < 1) {
       throw new IllegalArgumentException(

--- a/lib/src/test/java/com/scalar/admin/kubernetes/application/PauseApplicationServiceTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/application/PauseApplicationServiceTest.java
@@ -1,11 +1,18 @@
 package com.scalar.admin.kubernetes.application;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.scalar.admin.kubernetes.application.dto.PauseDurationDto;
 import com.scalar.admin.kubernetes.domain.client.ScalarAdminClient;
 import com.scalar.admin.kubernetes.domain.exception.PauserException;
+import com.scalar.admin.kubernetes.domain.model.pause.PauseByDeploymentNameCommand;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseByHelmReleaseCommand;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseDuration;
 import com.scalar.admin.kubernetes.domain.model.pause.PauseTarget;
@@ -15,6 +22,7 @@ import com.scalar.admin.kubernetes.domain.service.PauseService;
 import com.scalar.admin.kubernetes.domain.client.ScalarAdminClientFactory;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -34,160 +42,320 @@ class PauseApplicationServiceTest {
   }
 
   @Nested
+  @DisplayName("Constructor")
   class Constructor {
     @Test
-    void constructor_WithValidArgs_CreateInstance() {
+    @DisplayName("creates instance with valid arguments")
+    void createsInstanceWithValidArguments() {
       // Act & Assert
-      assertDoesNotThrow(
-          () -> new PauseApplicationService(kubernetesClient, scalarAdminClientFactory, pauseService));
+      assertThatCode(() -> new PauseApplicationService(kubernetesClient, scalarAdminClientFactory, pauseService))
+          .doesNotThrowAnyException();
     }
 
     @Test
-    void constructor_WithNullKubernetesClient_ThrowIllegalArgumentException() {
+    @DisplayName("throws IllegalArgumentException when kubernetesClient is null")
+    void throwsIllegalArgumentExceptionWhenRepositoryIsNull() {
       // Act & Assert
-      IllegalArgumentException thrown =
-          assertThrows(
-              IllegalArgumentException.class,
-              () -> new PauseApplicationService(null, scalarAdminClientFactory, pauseService));
-      assertEquals("kubernetesClient is required", thrown.getMessage());
+      assertThatThrownBy(() -> new PauseApplicationService(null, scalarAdminClientFactory, pauseService))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("kubernetesClient is required");
     }
 
     @Test
-    void constructor_WithNullClientFactory_ThrowIllegalArgumentException() {
+    @DisplayName("throws IllegalArgumentException when client factory is null")
+    void throwsIllegalArgumentExceptionWhenClientFactoryIsNull() {
       // Act & Assert
-      IllegalArgumentException thrown =
-          assertThrows(
-              IllegalArgumentException.class,
-              () -> new PauseApplicationService(kubernetesClient, null, pauseService));
-      assertEquals("clientFactory is required", thrown.getMessage());
+      assertThatThrownBy(() -> new PauseApplicationService(kubernetesClient, null, pauseService))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("clientFactory is required");
     }
 
     @Test
-    void constructor_WithNullPauseService_ThrowIllegalArgumentException() {
+    @DisplayName("throws IllegalArgumentException when pause service is null")
+    void throwsIllegalArgumentExceptionWhenPauseServiceIsNull() {
       // Act & Assert
-      IllegalArgumentException thrown =
-          assertThrows(
-              IllegalArgumentException.class,
-              () -> new PauseApplicationService(kubernetesClient, scalarAdminClientFactory, null));
-      assertEquals("pauseService is required", thrown.getMessage());
+      assertThatThrownBy(() -> new PauseApplicationService(kubernetesClient, scalarAdminClientFactory, null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("pauseService is required");
     }
   }
 
   @Nested
+  @DisplayName("execute()")
   class Execute {
-    @Test
-    void execute_WithNonTlsCommand_SuccessfullyPause() throws PauserException {
-      // Arrange
-      String namespace = "test-ns";
-      String helmReleaseName = "test-release";
-      int pauseDuration = 5000;
-      Long maxPauseWaitTime = 3000L;
 
-      PauseTarget target = mock(PauseTarget.class);
-      ScalarAdminClient client = mock(ScalarAdminClient.class);
-      Instant startTime = Instant.now();
-      Instant endTime = startTime.plusMillis(pauseDuration);
-      PauseDuration domainPauseDuration = new PauseDuration(startTime, endTime);
+    @Nested
+    @DisplayName("when command is null")
+    class WhenCommandIsNull {
 
-      PauseByHelmReleaseCommand command =
-          PauseByHelmReleaseCommand.create(
-              namespace, helmReleaseName, pauseDuration, maxPauseWaitTime);
-
-      when(kubernetesClient.resolvePauseTargetByHelmRelease(namespace, helmReleaseName)).thenReturn(target);
-      when(scalarAdminClientFactory.createClient(target)).thenReturn(client);
-      when(pauseService.pause(eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime)))
-          .thenReturn(domainPauseDuration);
-
-      // Act
-      PauseDurationDto actual = applicationService.execute(command);
-
-      // Assert
-      assertEquals(startTime.toEpochMilli(), actual.startTimeEpochMilli());
-      assertEquals(endTime.toEpochMilli(), actual.endTimeEpochMilli());
-      verify(kubernetesClient).resolvePauseTargetByHelmRelease(namespace, helmReleaseName);
-      verify(scalarAdminClientFactory).createClient(target);
-      verify(pauseService)
-          .pause(eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime));
+      @Test
+      @DisplayName("throws IllegalArgumentException")
+      void throwsIllegalArgumentException() {
+        // Act & Assert
+        assertThatThrownBy(() -> applicationService.execute(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("command is required");
+      }
     }
 
-    @Test
-    void execute_WithTlsCommand_SuccessfullyPause() throws PauserException {
-      // Arrange
-      String namespace = "test-ns";
-      String helmReleaseName = "test-release";
-      int pauseDuration = 5000;
-      Long maxPauseWaitTime = 3000L;
-      String caRootCert = "dummyCert";
-      String overrideAuthority = "dummyAuthority";
+    @Nested
+    @DisplayName("when command is PauseByHelmReleaseCommand")
+    class WhenCommandIsPauseByHelmReleaseCommand {
 
-      PauseTarget target = mock(PauseTarget.class);
-      ScalarAdminClient client = mock(ScalarAdminClient.class);
-      Instant startTime = Instant.now();
-      Instant endTime = startTime.plusMillis(pauseDuration);
-      PauseDuration domainPauseDuration = new PauseDuration(startTime, endTime);
+      @Test
+      @DisplayName("executes pause successfully with non-TLS command")
+      void executesPauseSuccessfullyWithNonTlsCommand() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String helmReleaseName = "test-release";
+        int pauseDuration = 5000;
+        Long maxPauseWaitTime = 3000L;
 
-      PauseByHelmReleaseCommand command =
-          PauseByHelmReleaseCommand.createWithTls(
-              namespace,
-              helmReleaseName,
-              pauseDuration,
-              maxPauseWaitTime,
-              caRootCert,
-              overrideAuthority);
+        PauseTarget target = mock(PauseTarget.class);
+        ScalarAdminClient client = mock(ScalarAdminClient.class);
+        Instant startTime = Instant.now();
+        Instant endTime = startTime.plusMillis(pauseDuration);
+        PauseDuration domainPauseDuration = new PauseDuration(startTime, endTime);
 
-      when(kubernetesClient.resolvePauseTargetByHelmRelease(namespace, helmReleaseName)).thenReturn(target);
-      when(scalarAdminClientFactory.createClient(eq(target), any(TlsConfig.class))).thenReturn(client);
-      when(pauseService.pause(eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime)))
-          .thenReturn(domainPauseDuration);
+        PauseByHelmReleaseCommand command =
+            PauseByHelmReleaseCommand.create(
+                namespace, helmReleaseName, pauseDuration, maxPauseWaitTime);
 
-      // Act
-      PauseDurationDto actual = applicationService.execute(command);
+        when(kubernetesClient.resolvePauseTargetByHelmRelease(namespace, helmReleaseName)).thenReturn(target);
+        when(scalarAdminClientFactory.createClient(target)).thenReturn(client);
+        when(pauseService.pause(
+                eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime)))
+            .thenReturn(domainPauseDuration);
 
-      // Assert
-      assertEquals(startTime.toEpochMilli(), actual.startTimeEpochMilli());
-      assertEquals(endTime.toEpochMilli(), actual.endTimeEpochMilli());
-      verify(kubernetesClient).resolvePauseTargetByHelmRelease(namespace, helmReleaseName);
-      verify(scalarAdminClientFactory).createClient(eq(target), any(TlsConfig.class));
-      verify(pauseService)
-          .pause(eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime));
+        // Act
+        PauseDurationDto actual = applicationService.execute(command);
+
+        // Assert
+        assertThat(actual.startTimeEpochMilli()).isEqualTo(startTime.toEpochMilli());
+        assertThat(actual.endTimeEpochMilli()).isEqualTo(endTime.toEpochMilli());
+        verify(kubernetesClient).resolvePauseTargetByHelmRelease(namespace, helmReleaseName);
+        verify(scalarAdminClientFactory).createClient(target);
+        verify(pauseService)
+            .pause(eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime));
+      }
+
+      @Test
+      @DisplayName("executes pause successfully with TLS command")
+      void executesPauseSuccessfullyWithTlsCommand() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String helmReleaseName = "test-release";
+        int pauseDuration = 5000;
+        Long maxPauseWaitTime = 3000L;
+        String caRootCert = "dummyCert";
+        String overrideAuthority = "dummyAuthority";
+
+        PauseTarget target = mock(PauseTarget.class);
+        ScalarAdminClient client = mock(ScalarAdminClient.class);
+        Instant startTime = Instant.now();
+        Instant endTime = startTime.plusMillis(pauseDuration);
+        PauseDuration domainPauseDuration = new PauseDuration(startTime, endTime);
+
+        PauseByHelmReleaseCommand command =
+            PauseByHelmReleaseCommand.createWithTls(
+                namespace,
+                helmReleaseName,
+                pauseDuration,
+                maxPauseWaitTime,
+                caRootCert,
+                overrideAuthority);
+
+        when(kubernetesClient.resolvePauseTargetByHelmRelease(namespace, helmReleaseName)).thenReturn(target);
+        when(scalarAdminClientFactory.createClient(eq(target), any(TlsConfig.class))).thenReturn(client);
+        when(pauseService.pause(
+                eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime)))
+            .thenReturn(domainPauseDuration);
+
+        // Act
+        PauseDurationDto actual = applicationService.execute(command);
+
+        // Assert
+        assertThat(actual.startTimeEpochMilli()).isEqualTo(startTime.toEpochMilli());
+        assertThat(actual.endTimeEpochMilli()).isEqualTo(endTime.toEpochMilli());
+        verify(kubernetesClient).resolvePauseTargetByHelmRelease(namespace, helmReleaseName);
+        verify(scalarAdminClientFactory).createClient(eq(target), any(TlsConfig.class));
+        verify(pauseService)
+            .pause(eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime));
+      }
+
+      @Test
+      @DisplayName("throws PauserException when kubernetesClient throws exception")
+      void throwsPauserExceptionWhenRepositoryThrowsException() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String helmReleaseName = "test-release";
+
+        PauseByHelmReleaseCommand command =
+            PauseByHelmReleaseCommand.create(namespace, helmReleaseName, 5000, 3000L);
+
+        when(kubernetesClient.resolvePauseTargetByHelmRelease(namespace, helmReleaseName))
+            .thenThrow(new RuntimeException("Repository error"));
+
+        // Act & Assert
+        assertThatThrownBy(() -> applicationService.execute(command))
+            .isInstanceOf(PauserException.class)
+            .hasMessage("Failed to find the target pods to pause.");
+      }
+
+      @Test
+      @DisplayName("throws PauserException when client factory throws exception")
+      void throwsPauserExceptionWhenClientFactoryThrowsException() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String helmReleaseName = "test-release";
+
+        PauseTarget target = mock(PauseTarget.class);
+        PauseByHelmReleaseCommand command =
+            PauseByHelmReleaseCommand.create(namespace, helmReleaseName, 5000, 3000L);
+
+        when(kubernetesClient.resolvePauseTargetByHelmRelease(namespace, helmReleaseName)).thenReturn(target);
+        when(scalarAdminClientFactory.createClient(target))
+            .thenThrow(new RuntimeException("Client factory error"));
+
+        // Act & Assert
+        assertThatThrownBy(() -> applicationService.execute(command))
+            .isInstanceOf(PauserException.class)
+            .hasMessage("Failed to initialize the Scalar Admin client.");
+      }
     }
 
-    @Test
-    void execute_WhenRepositoryThrowsException_ThrowPauserException() throws PauserException {
-      // Arrange
-      String namespace = "test-ns";
-      String helmReleaseName = "test-release";
+    @Nested
+    @DisplayName("when command is PauseByDeploymentNameCommand")
+    class WhenCommandIsPauseByDeploymentNameCommand {
 
-      PauseByHelmReleaseCommand command =
-          PauseByHelmReleaseCommand.create(namespace, helmReleaseName, 5000, 3000L);
+      @Test
+      @DisplayName("executes pause successfully with non-TLS command")
+      void executesPauseSuccessfullyWithNonTlsCommand() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String deploymentName = "test-deployment";
+        int adminPort = 60054;
+        int pauseDuration = 5000;
+        Long maxPauseWaitTime = 3000L;
 
-      when(kubernetesClient.resolvePauseTargetByHelmRelease(namespace, helmReleaseName))
-          .thenThrow(new PauserException("Can not find any target pods."));
+        PauseTarget target = mock(PauseTarget.class);
+        ScalarAdminClient client = mock(ScalarAdminClient.class);
+        Instant startTime = Instant.now();
+        Instant endTime = startTime.plusMillis(pauseDuration);
+        PauseDuration domainPauseDuration = new PauseDuration(startTime, endTime);
 
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> applicationService.execute(command));
-      assertEquals("Can not find any target pods.", thrown.getMessage());
-    }
+        PauseByDeploymentNameCommand command =
+            PauseByDeploymentNameCommand.create(
+                namespace, deploymentName, adminPort, pauseDuration, maxPauseWaitTime);
 
-    @Test
-    void execute_WhenClientFactoryThrowsException_ThrowPauserException() throws PauserException {
-      // Arrange
-      String namespace = "test-ns";
-      String helmReleaseName = "test-release";
+        when(kubernetesClient.resolvePauseTargetByDeploymentName(namespace, deploymentName, adminPort))
+            .thenReturn(target);
+        when(scalarAdminClientFactory.createClient(target)).thenReturn(client);
+        when(pauseService.pause(
+                eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime)))
+            .thenReturn(domainPauseDuration);
 
-      PauseTarget target = mock(PauseTarget.class);
-      PauseByHelmReleaseCommand command =
-          PauseByHelmReleaseCommand.create(namespace, helmReleaseName, 5000, 3000L);
+        // Act
+        PauseDurationDto actual = applicationService.execute(command);
 
-      when(kubernetesClient.resolvePauseTargetByHelmRelease(namespace, helmReleaseName)).thenReturn(target);
-      when(scalarAdminClientFactory.createClient(target))
-          .thenThrow(new RuntimeException("Client factory error"));
+        // Assert
+        assertThat(actual.startTimeEpochMilli()).isEqualTo(startTime.toEpochMilli());
+        assertThat(actual.endTimeEpochMilli()).isEqualTo(endTime.toEpochMilli());
+        verify(kubernetesClient).resolvePauseTargetByDeploymentName(namespace, deploymentName, adminPort);
+        verify(scalarAdminClientFactory).createClient(target);
+        verify(pauseService)
+            .pause(eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime));
+      }
 
-      // Act & Assert
-      PauserException thrown =
-          assertThrows(PauserException.class, () -> applicationService.execute(command));
-      assertEquals("Failed to initialize the Scalar Admin client.", thrown.getMessage());
+      @Test
+      @DisplayName("executes pause successfully with TLS command")
+      void executesPauseSuccessfullyWithTlsCommand() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String deploymentName = "test-deployment";
+        int adminPort = 60054;
+        int pauseDuration = 5000;
+        Long maxPauseWaitTime = 3000L;
+        String caRootCert = "dummyCert";
+        String overrideAuthority = "dummyAuthority";
+
+        PauseTarget target = mock(PauseTarget.class);
+        ScalarAdminClient client = mock(ScalarAdminClient.class);
+        Instant startTime = Instant.now();
+        Instant endTime = startTime.plusMillis(pauseDuration);
+        PauseDuration domainPauseDuration = new PauseDuration(startTime, endTime);
+
+        PauseByDeploymentNameCommand command =
+            PauseByDeploymentNameCommand.createWithTls(
+                namespace,
+                deploymentName,
+                adminPort,
+                pauseDuration,
+                maxPauseWaitTime,
+                caRootCert,
+                overrideAuthority);
+
+        when(kubernetesClient.resolvePauseTargetByDeploymentName(namespace, deploymentName, adminPort))
+            .thenReturn(target);
+        when(scalarAdminClientFactory.createClient(eq(target), any(TlsConfig.class))).thenReturn(client);
+        when(pauseService.pause(
+                eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime)))
+            .thenReturn(domainPauseDuration);
+
+        // Act
+        PauseDurationDto actual = applicationService.execute(command);
+
+        // Assert
+        assertThat(actual.startTimeEpochMilli()).isEqualTo(startTime.toEpochMilli());
+        assertThat(actual.endTimeEpochMilli()).isEqualTo(endTime.toEpochMilli());
+        verify(kubernetesClient).resolvePauseTargetByDeploymentName(namespace, deploymentName, adminPort);
+        verify(scalarAdminClientFactory).createClient(eq(target), any(TlsConfig.class));
+        verify(pauseService)
+            .pause(eq(target), any(), eq(client), eq(pauseDuration), eq(maxPauseWaitTime));
+      }
+
+      @Test
+      @DisplayName("throws PauserException when kubernetesClient throws exception")
+      void throwsPauserExceptionWhenRepositoryThrowsException() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String deploymentName = "test-deployment";
+        int adminPort = 60054;
+
+        PauseByDeploymentNameCommand command =
+            PauseByDeploymentNameCommand.create(namespace, deploymentName, adminPort, 5000, 3000L);
+
+        when(kubernetesClient.resolvePauseTargetByDeploymentName(namespace, deploymentName, adminPort))
+            .thenThrow(new RuntimeException("Repository error"));
+
+        // Act & Assert
+        assertThatThrownBy(() -> applicationService.execute(command))
+            .isInstanceOf(PauserException.class)
+            .hasMessage("Failed to find the target pods to pause.");
+      }
+
+      @Test
+      @DisplayName("throws PauserException when client factory throws exception")
+      void throwsPauserExceptionWhenClientFactoryThrowsException() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String deploymentName = "test-deployment";
+        int adminPort = 60054;
+
+        PauseTarget target = mock(PauseTarget.class);
+        PauseByDeploymentNameCommand command =
+            PauseByDeploymentNameCommand.create(namespace, deploymentName, adminPort, 5000, 3000L);
+
+        when(kubernetesClient.resolvePauseTargetByDeploymentName(namespace, deploymentName, adminPort))
+            .thenReturn(target);
+        when(scalarAdminClientFactory.createClient(target))
+            .thenThrow(new RuntimeException("Client factory error"));
+
+        // Act & Assert
+        assertThatThrownBy(() -> applicationService.execute(command))
+            .isInstanceOf(PauserException.class)
+            .hasMessage("Failed to initialize the Scalar Admin client.");
+      }
     }
   }
 }

--- a/lib/src/test/java/com/scalar/admin/kubernetes/application/PauseApplicationServiceTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/application/PauseApplicationServiceTest.java
@@ -184,8 +184,8 @@ class PauseApplicationServiceTest {
       }
 
       @Test
-      @DisplayName("throws PauserException when kubernetesClient throws exception")
-      void throwsPauserExceptionWhenRepositoryThrowsException() throws PauserException {
+      @DisplayName("wraps RuntimeException from kubernetesClient in PauserException")
+      void wrapsRuntimeExceptionFromRepositoryInPauserException() throws PauserException {
         // Arrange
         String namespace = "test-ns";
         String helmReleaseName = "test-release";
@@ -200,6 +200,26 @@ class PauseApplicationServiceTest {
         assertThatThrownBy(() -> applicationService.execute(command))
             .isInstanceOf(PauserException.class)
             .hasMessage("Failed to find the target pods to pause.");
+      }
+
+      @Test
+      @DisplayName("propagates PauserException from kubernetesClient without wrapping")
+      void propagatesPauserExceptionFromRepositoryWithoutWrapping() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String helmReleaseName = "test-release";
+
+        PauseByHelmReleaseCommand command =
+            PauseByHelmReleaseCommand.create(namespace, helmReleaseName, 5000, 3000L);
+
+        PauserException original = new PauserException("Can not find any target pods.");
+        when(kubernetesClient.resolvePauseTargetByHelmRelease(namespace, helmReleaseName))
+            .thenThrow(original);
+
+        // Act & Assert
+        assertThatThrownBy(() -> applicationService.execute(command))
+            .isSameAs(original)
+            .hasMessage("Can not find any target pods.");
       }
 
       @Test
@@ -315,8 +335,8 @@ class PauseApplicationServiceTest {
       }
 
       @Test
-      @DisplayName("throws PauserException when kubernetesClient throws exception")
-      void throwsPauserExceptionWhenRepositoryThrowsException() throws PauserException {
+      @DisplayName("wraps RuntimeException from kubernetesClient in PauserException")
+      void wrapsRuntimeExceptionFromRepositoryInPauserException() throws PauserException {
         // Arrange
         String namespace = "test-ns";
         String deploymentName = "test-deployment";
@@ -332,6 +352,27 @@ class PauseApplicationServiceTest {
         assertThatThrownBy(() -> applicationService.execute(command))
             .isInstanceOf(PauserException.class)
             .hasMessage("Failed to find the target pods to pause.");
+      }
+
+      @Test
+      @DisplayName("propagates PauserException from kubernetesClient without wrapping")
+      void propagatesPauserExceptionFromRepositoryWithoutWrapping() throws PauserException {
+        // Arrange
+        String namespace = "test-ns";
+        String deploymentName = "test-deployment";
+        int adminPort = 60054;
+
+        PauseByDeploymentNameCommand command =
+            PauseByDeploymentNameCommand.create(namespace, deploymentName, adminPort, 5000, 3000L);
+
+        PauserException original = new PauserException("Deployment does not have any running pods.");
+        when(kubernetesClient.resolvePauseTargetByDeploymentName(namespace, deploymentName, adminPort))
+            .thenThrow(original);
+
+        // Act & Assert
+        assertThatThrownBy(() -> applicationService.execute(command))
+            .isSameAs(original)
+            .hasMessage("Deployment does not have any running pods.");
       }
 
       @Test

--- a/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommandTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommandTest.java
@@ -140,7 +140,7 @@ class PauseByDeploymentNameCommandTest {
     class WhenAdminPortIsInvalid {
 
       @ParameterizedTest
-      @ValueSource(ints = {-1, -100, 65536, 70000})
+      @ValueSource(ints = {0, -1, -100, 65536, 70000})
       @DisplayName("throws IllegalArgumentException for out-of-range port")
       void throwsIllegalArgumentExceptionForOutOfRangePort(int invalidPort) {
         // Arrange & Act & Assert
@@ -149,7 +149,7 @@ class PauseByDeploymentNameCommandTest {
                     PauseByDeploymentNameCommand.create(
                         "default", "my-deployment", invalidPort, 10000, null))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("adminPort must be between 0 and 65535, but was: " + invalidPort);
+            .hasMessage("adminPort must be between 1 and 65535, but was: " + invalidPort);
       }
     }
 
@@ -158,7 +158,7 @@ class PauseByDeploymentNameCommandTest {
     class WhenAdminPortIsValid {
 
       @ParameterizedTest
-      @ValueSource(ints = {0, 1, 80, 8080, 60054, 65535})
+      @ValueSource(ints = {1, 80, 8080, 60054, 65535})
       @DisplayName("creates command successfully for valid port")
       void createsCommandSuccessfullyForValidPort(int validPort) {
         // Arrange & Act & Assert

--- a/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommandTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommandTest.java
@@ -1,0 +1,210 @@
+package com.scalar.admin.kubernetes.domain.model.pause;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PauseByDeploymentNameCommandTest {
+
+  @Nested
+  @DisplayName("create()")
+  class Create {
+
+    @Test
+    @DisplayName("creates command without TLS successfully")
+    void createsCommandWithoutTls() {
+      // Arrange & Act
+      PauseByDeploymentNameCommand command =
+          PauseByDeploymentNameCommand.create(
+              "default", "my-deployment", 60054, 10000, 30000L);
+
+      // Assert
+      assertThat(command.namespace()).isEqualTo("default");
+      assertThat(command.deploymentName()).isEqualTo("my-deployment");
+      assertThat(command.adminPort()).isEqualTo(60054);
+      assertThat(command.pauseDuration()).isEqualTo(10000);
+      assertThat(command.maxPauseWaitTime()).isEqualTo(30000L);
+      assertThat(command.tlsConfig()).isNull();
+    }
+
+    @Test
+    @DisplayName("creates command with null maxPauseWaitTime successfully")
+    void createsCommandWithNullMaxPauseWaitTime() {
+      // Arrange & Act
+      PauseByDeploymentNameCommand command =
+          PauseByDeploymentNameCommand.create("default", "my-deployment", 60054, 10000, null);
+
+      // Assert
+      assertThat(command.maxPauseWaitTime()).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("createWithTls()")
+  class CreateWithTls {
+
+    @Test
+    @DisplayName("creates command with TLS successfully")
+    void createsCommandWithTls() {
+      // Arrange & Act
+      PauseByDeploymentNameCommand command =
+          PauseByDeploymentNameCommand.createWithTls(
+              "default",
+              "my-deployment",
+              60054,
+              10000,
+              30000L,
+              "ca-root-cert-content",
+              "override-authority");
+
+      // Assert
+      assertThat(command.namespace()).isEqualTo("default");
+      assertThat(command.deploymentName()).isEqualTo("my-deployment");
+      assertThat(command.adminPort()).isEqualTo(60054);
+      assertThat(command.pauseDuration()).isEqualTo(10000);
+      assertThat(command.maxPauseWaitTime()).isEqualTo(30000L);
+      assertThat(command.tlsConfig()).isNotNull();
+      assertThat(command.tlsConfig().caRootCert()).isEqualTo("ca-root-cert-content");
+      assertThat(command.tlsConfig().overrideAuthority()).isEqualTo("override-authority");
+    }
+  }
+
+  @Nested
+  @DisplayName("podDiscoveryMode()")
+  class PodDiscoveryMode {
+
+    @Test
+    @DisplayName("returns DEPLOYMENT mode")
+    void returnsDeploymentMode() {
+      // Arrange
+      PauseByDeploymentNameCommand command =
+          PauseByDeploymentNameCommand.create("default", "my-deployment", 60054, 10000, null);
+
+      // Act & Assert
+      assertThat(command.podDiscoveryMode()).isEqualTo(
+          com.scalar.admin.kubernetes.domain.model.pause.PodDiscoveryMode.DEPLOYMENT);
+    }
+  }
+
+  @Nested
+  @DisplayName("validation")
+  class Validation {
+
+    @Nested
+    @DisplayName("when namespace is invalid")
+    class WhenNamespaceIsInvalid {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"  ", "   "})
+      @DisplayName("throws IllegalArgumentException")
+      void throwsIllegalArgumentException(String invalidNamespace) {
+        // Arrange & Act & Assert
+        assertThatThrownBy(
+                () ->
+                    PauseByDeploymentNameCommand.create(
+                        invalidNamespace, "my-deployment", 60054, 10000, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("namespace is required");
+      }
+    }
+
+    @Nested
+    @DisplayName("when deploymentName is invalid")
+    class WhenDeploymentNameIsInvalid {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"  ", "   "})
+      @DisplayName("throws IllegalArgumentException")
+      void throwsIllegalArgumentException(String invalidDeploymentName) {
+        // Arrange & Act & Assert
+        assertThatThrownBy(
+                () ->
+                    PauseByDeploymentNameCommand.create(
+                        "default", invalidDeploymentName, 60054, 10000, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("deploymentName is required");
+      }
+    }
+
+    @Nested
+    @DisplayName("when adminPort is invalid")
+    class WhenAdminPortIsInvalid {
+
+      @ParameterizedTest
+      @ValueSource(ints = {-1, -100, 65536, 70000})
+      @DisplayName("throws IllegalArgumentException for out-of-range port")
+      void throwsIllegalArgumentExceptionForOutOfRangePort(int invalidPort) {
+        // Arrange & Act & Assert
+        assertThatThrownBy(
+                () ->
+                    PauseByDeploymentNameCommand.create(
+                        "default", "my-deployment", invalidPort, 10000, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("adminPort must be between 0 and 65535, but was: " + invalidPort);
+      }
+    }
+
+    @Nested
+    @DisplayName("when adminPort is valid")
+    class WhenAdminPortIsValid {
+
+      @ParameterizedTest
+      @ValueSource(ints = {0, 1, 80, 8080, 60054, 65535})
+      @DisplayName("creates command successfully for valid port")
+      void createsCommandSuccessfullyForValidPort(int validPort) {
+        // Arrange & Act & Assert
+        assertThatCode(
+                () ->
+                    PauseByDeploymentNameCommand.create(
+                        "default", "my-deployment", validPort, 10000, null))
+            .doesNotThrowAnyException();
+      }
+    }
+
+    @Nested
+    @DisplayName("when pauseDuration is invalid")
+    class WhenPauseDurationIsInvalid {
+
+      @ParameterizedTest
+      @ValueSource(ints = {0, -1, -100})
+      @DisplayName("throws IllegalArgumentException")
+      void throwsIllegalArgumentException(int invalidPauseDuration) {
+        // Arrange & Act & Assert
+        assertThatThrownBy(
+                () ->
+                    PauseByDeploymentNameCommand.create(
+                        "default", "my-deployment", 60054, invalidPauseDuration, null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(
+                "pauseDuration must be greater than 0 millisecond, but was: "
+                    + invalidPauseDuration);
+      }
+    }
+
+    @Nested
+    @DisplayName("when pauseDuration is valid")
+    class WhenPauseDurationIsValid {
+
+      @ParameterizedTest
+      @ValueSource(ints = {1, 10000, 100000})
+      @DisplayName("creates command successfully")
+      void createsCommandSuccessfully(int validPauseDuration) {
+        // Arrange & Act & Assert
+        assertThatCode(
+                () ->
+                    PauseByDeploymentNameCommand.create(
+                        "default", "my-deployment", 60054, validPauseDuration, null))
+            .doesNotThrowAnyException();
+      }
+    }
+  }
+}

--- a/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PauseTargetTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PauseTargetTest.java
@@ -83,7 +83,7 @@ public class PauseTargetTest {
     class WhenAdminPortIsInvalid {
 
       @ParameterizedTest
-      @ValueSource(ints = {0, -1, -100})
+      @ValueSource(ints = {0, -1, -100, 65536, 70000})
       @DisplayName("throws IllegalArgumentException")
       void throwsIllegalArgumentException(int invalidPort) {
         // Arrange
@@ -93,7 +93,7 @@ public class PauseTargetTest {
         // Act & Assert
         assertThatThrownBy(() -> new PauseTarget(Arrays.asList(pod), deployment, invalidPort))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("adminPort must be greater than 0");
+            .hasMessage(String.format(PauseCommand.ADMIN_PORT_ERROR, invalidPort));
       }
     }
   }

--- a/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryModeTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryModeTest.java
@@ -23,6 +23,13 @@ class PodDiscoveryModeTest {
       // Arrange & Act & Assert
       assertThat(PodDiscoveryMode.HELM_RELEASE.getValue()).isEqualTo("helm-release");
     }
+
+    @Test
+    @DisplayName("returns correct value for DEPLOYMENT")
+    void returnsCorrectValueForDeployment() {
+      // Arrange & Act & Assert
+      assertThat(PodDiscoveryMode.DEPLOYMENT.getValue()).isEqualTo("deployment");
+    }
   }
 
   @Nested
@@ -48,6 +55,22 @@ class PodDiscoveryModeTest {
         assertThat(PodDiscoveryMode.fromValue("HELM-RELEASE"))
             .isEqualTo(PodDiscoveryMode.HELM_RELEASE);
       }
+
+      @Test
+      @DisplayName("converts 'deployment' to DEPLOYMENT")
+      void convertsDeployment() {
+        // Arrange & Act & Assert
+        assertThat(PodDiscoveryMode.fromValue("deployment"))
+            .isEqualTo(PodDiscoveryMode.DEPLOYMENT);
+      }
+
+      @Test
+      @DisplayName("converts 'DEPLOYMENT' to DEPLOYMENT (case insensitive)")
+      void convertsDeploymentCaseInsensitive() {
+        // Arrange & Act & Assert
+        assertThat(PodDiscoveryMode.fromValue("DEPLOYMENT"))
+            .isEqualTo(PodDiscoveryMode.DEPLOYMENT);
+      }
     }
 
     @Nested
@@ -66,13 +89,16 @@ class PodDiscoveryModeTest {
       }
 
       @ParameterizedTest
-      @ValueSource(strings = {"invalid", "unknown", "deployment"})
+      @ValueSource(strings = {"invalid", "unknown", "helm_release", "deploy"})
       @DisplayName("throws IllegalArgumentException for unknown value")
       void throwsIllegalArgumentExceptionForUnknownValue(String invalidValue) {
         // Arrange & Act & Assert
         assertThatThrownBy(() -> PodDiscoveryMode.fromValue(invalidValue))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Invalid podDiscoveryMode: " + invalidValue + ". Valid values are: helm-release");
+            .hasMessage(
+                "Invalid podDiscoveryMode: "
+                    + invalidValue
+                    + ". Valid values are: helm-release, deployment");
       }
     }
   }
@@ -93,7 +119,7 @@ class PodDiscoveryModeTest {
         @DisplayName("validates successfully")
         void validatesSuccessfully() {
           // Arrange & Act & Assert
-          assertThatCode(() -> PodDiscoveryMode.HELM_RELEASE.validate("my-release"))
+          assertThatCode(() -> PodDiscoveryMode.HELM_RELEASE.validate("my-release", null, null))
               .doesNotThrowAnyException();
         }
       }
@@ -108,9 +134,118 @@ class PodDiscoveryModeTest {
         @DisplayName("throws IllegalArgumentException")
         void throwsIllegalArgumentException(String invalidHelmReleaseName) {
           // Arrange & Act & Assert
-          assertThatThrownBy(() -> PodDiscoveryMode.HELM_RELEASE.validate(invalidHelmReleaseName))
+          assertThatThrownBy(
+                  () -> PodDiscoveryMode.HELM_RELEASE.validate(invalidHelmReleaseName, null, null))
               .isInstanceOf(IllegalArgumentException.class)
               .hasMessage("helmReleaseName is required when podDiscoveryMode is HELM_RELEASE");
+        }
+      }
+
+      @Nested
+      @DisplayName("when deploymentName is specified")
+      class WhenDeploymentNameIsSpecified {
+
+        @Test
+        @DisplayName("throws IllegalArgumentException")
+        void throwsIllegalArgumentException() {
+          // Arrange & Act & Assert
+          assertThatThrownBy(
+                  () ->
+                      PodDiscoveryMode.HELM_RELEASE.validate(
+                          "my-release", "my-deployment", null))
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage(
+                  "deploymentName and adminPort cannot be used when podDiscoveryMode is"
+                      + " HELM_RELEASE");
+        }
+      }
+
+      @Nested
+      @DisplayName("when adminPort is specified")
+      class WhenAdminPortIsSpecified {
+
+        @Test
+        @DisplayName("throws IllegalArgumentException")
+        void throwsIllegalArgumentException() {
+          // Arrange & Act & Assert
+          assertThatThrownBy(
+                  () -> PodDiscoveryMode.HELM_RELEASE.validate("my-release", null, 60054))
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage(
+                  "deploymentName and adminPort cannot be used when podDiscoveryMode is"
+                      + " HELM_RELEASE");
+        }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("DEPLOYMENT mode")
+  class DeploymentMode {
+
+    @Nested
+    @DisplayName("validate method")
+    class ValidateMethod {
+
+      @Nested
+      @DisplayName("when deploymentName and adminPort are valid")
+      class WhenDeploymentNameAndAdminPortAreValid {
+
+        @Test
+        @DisplayName("validates successfully")
+        void validatesSuccessfully() {
+          // Arrange & Act & Assert
+          assertThatCode(
+                  () -> PodDiscoveryMode.DEPLOYMENT.validate(null, "my-deployment", 60054))
+              .doesNotThrowAnyException();
+        }
+      }
+
+      @Nested
+      @DisplayName("when deploymentName is invalid")
+      class WhenDeploymentNameIsInvalid {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"  ", "   "})
+        @DisplayName("throws IllegalArgumentException")
+        void throwsIllegalArgumentException(String invalidDeploymentName) {
+          // Arrange & Act & Assert
+          assertThatThrownBy(
+                  () -> PodDiscoveryMode.DEPLOYMENT.validate(null, invalidDeploymentName, 60054))
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage("deploymentName is required when podDiscoveryMode is DEPLOYMENT");
+        }
+      }
+
+      @Nested
+      @DisplayName("when adminPort is null")
+      class WhenAdminPortIsNull {
+
+        @Test
+        @DisplayName("throws IllegalArgumentException")
+        void throwsIllegalArgumentException() {
+          // Arrange & Act & Assert
+          assertThatThrownBy(
+                  () -> PodDiscoveryMode.DEPLOYMENT.validate(null, "my-deployment", null))
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage("adminPort is required when podDiscoveryMode is DEPLOYMENT");
+        }
+      }
+
+      @Nested
+      @DisplayName("when helmReleaseName is specified")
+      class WhenHelmReleaseNameIsSpecified {
+
+        @Test
+        @DisplayName("throws IllegalArgumentException")
+        void throwsIllegalArgumentException() {
+          // Arrange & Act & Assert
+          assertThatThrownBy(
+                  () ->
+                      PodDiscoveryMode.DEPLOYMENT.validate("my-release", "my-deployment", 60054))
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage("helmReleaseName cannot be used when podDiscoveryMode is DEPLOYMENT");
         }
       }
     }

--- a/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryModeTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryModeTest.java
@@ -234,6 +234,21 @@ class PodDiscoveryModeTest {
       }
 
       @Nested
+      @DisplayName("when adminPort is out-of-range")
+      class WhenAdminPortIsOutOfRange {
+        @ParameterizedTest
+        @ValueSource(ints = {0, -1, -100, 65536, 70000})
+        @DisplayName("throws IllegalArgumentException")
+        void throwsIllegalArgumentException(int invalidPort) {
+            // Arrange & Act & Assert
+            assertThatThrownBy(
+                    () -> PodDiscoveryMode.DEPLOYMENT.validate(null, "my-deployment", invalidPort))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("adminPort must be between 1 and 65535 when podDiscoveryMode is DEPLOYMENT, but was: " + invalidPort);
+        }
+      }
+
+      @Nested
       @DisplayName("when helmReleaseName is specified")
       class WhenHelmReleaseNameIsSpecified {
 

--- a/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryModeTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryModeTest.java
@@ -1,0 +1,118 @@
+package com.scalar.admin.kubernetes.domain.model.pause;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PodDiscoveryModeTest {
+
+  @Nested
+  @DisplayName("getValue method")
+  class GetValueMethod {
+
+    @Test
+    @DisplayName("returns correct value for HELM_RELEASE")
+    void returnsCorrectValueForHelmRelease() {
+      // Arrange & Act & Assert
+      assertThat(PodDiscoveryMode.HELM_RELEASE.getValue()).isEqualTo("helm-release");
+    }
+  }
+
+  @Nested
+  @DisplayName("fromValue method")
+  class FromValueMethod {
+
+    @Nested
+    @DisplayName("when given valid values")
+    class WhenGivenValidValues {
+
+      @Test
+      @DisplayName("converts 'helm-release' to HELM_RELEASE")
+      void convertsHelmRelease() {
+        // Arrange & Act & Assert
+        assertThat(PodDiscoveryMode.fromValue("helm-release"))
+            .isEqualTo(PodDiscoveryMode.HELM_RELEASE);
+      }
+
+      @Test
+      @DisplayName("converts 'HELM-RELEASE' to HELM_RELEASE (case insensitive)")
+      void convertsHelmReleaseCaseInsensitive() {
+        // Arrange & Act & Assert
+        assertThat(PodDiscoveryMode.fromValue("HELM-RELEASE"))
+            .isEqualTo(PodDiscoveryMode.HELM_RELEASE);
+      }
+    }
+
+    @Nested
+    @DisplayName("when given invalid values")
+    class WhenGivenInvalidValues {
+
+      @ParameterizedTest
+      @NullAndEmptySource
+      @ValueSource(strings = {"  ", "   "})
+      @DisplayName("throws IllegalArgumentException for null or blank")
+      void throwsIllegalArgumentExceptionForNullOrBlank(String invalidValue) {
+        // Arrange & Act & Assert
+        assertThatThrownBy(() -> PodDiscoveryMode.fromValue(invalidValue))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("podDiscoveryMode value cannot be null or blank");
+      }
+
+      @ParameterizedTest
+      @ValueSource(strings = {"invalid", "unknown", "deployment"})
+      @DisplayName("throws IllegalArgumentException for unknown value")
+      void throwsIllegalArgumentExceptionForUnknownValue(String invalidValue) {
+        // Arrange & Act & Assert
+        assertThatThrownBy(() -> PodDiscoveryMode.fromValue(invalidValue))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid podDiscoveryMode: " + invalidValue + ". Valid values are: helm-release");
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("HELM_RELEASE mode")
+  class HelmReleaseMode {
+
+    @Nested
+    @DisplayName("validate method")
+    class ValidateMethod {
+
+      @Nested
+      @DisplayName("when helmReleaseName is valid")
+      class WhenHelmReleaseNameIsValid {
+
+        @Test
+        @DisplayName("validates successfully")
+        void validatesSuccessfully() {
+          // Arrange & Act & Assert
+          assertThatCode(() -> PodDiscoveryMode.HELM_RELEASE.validate("my-release"))
+              .doesNotThrowAnyException();
+        }
+      }
+
+      @Nested
+      @DisplayName("when helmReleaseName is invalid")
+      class WhenHelmReleaseNameIsInvalid {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"  ", "   "})
+        @DisplayName("throws IllegalArgumentException")
+        void throwsIllegalArgumentException(String invalidHelmReleaseName) {
+          // Arrange & Act & Assert
+          assertThatThrownBy(() -> PodDiscoveryMode.HELM_RELEASE.validate(invalidHelmReleaseName))
+              .isInstanceOf(IllegalArgumentException.class)
+              .hasMessage("helmReleaseName is required when podDiscoveryMode is HELM_RELEASE");
+        }
+      }
+    }
+  }
+}

--- a/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryModeTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryModeTest.java
@@ -234,21 +234,6 @@ class PodDiscoveryModeTest {
       }
 
       @Nested
-      @DisplayName("when adminPort is out-of-range")
-      class WhenAdminPortIsOutOfRange {
-        @ParameterizedTest
-        @ValueSource(ints = {0, -1, -100, 65536, 70000})
-        @DisplayName("throws IllegalArgumentException")
-        void throwsIllegalArgumentException(int invalidPort) {
-            // Arrange & Act & Assert
-            assertThatThrownBy(
-                    () -> PodDiscoveryMode.DEPLOYMENT.validate(null, "my-deployment", invalidPort))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("adminPort must be between 1 and 65535 when podDiscoveryMode is DEPLOYMENT, but was: " + invalidPort);
-        }
-      }
-
-      @Nested
       @DisplayName("when helmReleaseName is specified")
       class WhenHelmReleaseNameIsSpecified {
 

--- a/lib/src/test/java/com/scalar/admin/kubernetes/domain/service/PauseServiceTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/domain/service/PauseServiceTest.java
@@ -145,23 +145,6 @@ class PauseServiceTest {
     }
 
     @Test
-    void pause_LessThanOnePauseDuration_ShouldThrowIllegalArgumentException() {
-      // Arrange
-      int pauseDuration = 0;
-      PauseService service = new PauseService();
-
-      // Act & Assert
-      IllegalArgumentException thrown =
-          assertThrows(
-              IllegalArgumentException.class,
-              () ->
-                  service.pause(
-                      targetBeforePause, () -> targetAfterPause, client, pauseDuration, null));
-      assertEquals(
-          "pauseDuration is required to be greater than 0 millisecond.", thrown.getMessage());
-    }
-
-    @Test
     void pause_WhenClientPauseThrowException_ShouldThrowPauseFailedException()
         throws PauserException {
       // Arrange

--- a/lib/src/test/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImplTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImplTest.java
@@ -1,5 +1,7 @@
 package com.scalar.admin.kubernetes.infrastructure.client;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,6 +18,8 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ContainerStatus;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1DeploymentList;
+import io.kubernetes.client.openapi.models.V1DeploymentSpec;
+import io.kubernetes.client.openapi.models.V1LabelSelector;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
@@ -31,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class KubernetesClientImplTest {
@@ -44,7 +50,7 @@ public class KubernetesClientImplTest {
     appsV1Api = mock(AppsV1Api.class);
 
     mockCoreV1Api();
-    mockAppsV1Api();
+    mockAppsV1ApiForListNamespacedDeployment();
   }
 
   
@@ -583,6 +589,331 @@ public class KubernetesClientImplTest {
     assertTrue(podNames.contains("pod2"));
   }
 
+  @Nested
+  @DisplayName("getDeployment()")
+  class GetDeployment {
+
+    @BeforeEach
+    void setUp() throws ApiException {
+      mockAppsV1ApiForReadNamespacedDeployment();
+    }
+
+    @Nested
+    @DisplayName("when deployment exists")
+    class WhenDeploymentExists {
+
+      @Test
+      @DisplayName("returns V1Deployment")
+      void returnsV1Deployment() throws ApiException, PauserException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act
+        V1Deployment deployment = kubernetesClient.getDeployment(namespace, deploymentName);
+
+        // Assert
+        assertEquals(deploymentName, deployment.getMetadata().getName());
+        assertEquals(namespace, deployment.getMetadata().getNamespace());
+      }
+    }
+
+    @Nested
+    @DisplayName("when readNamespacedDeployment throws ApiException")
+    class WhenReadNamespacedDeploymentThrowsApiException {
+
+      @Test
+      @DisplayName("throws PauserException")
+      void throwsPauserException() throws ApiException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+
+        when(appsV1Api.readNamespacedDeployment(deploymentName, namespace, null))
+            .thenThrow(new ApiException("", 404, null, "mock response body"));
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act & Assert
+        assertThatThrownBy(() -> kubernetesClient.getDeployment(namespace, deploymentName))
+            .isInstanceOf(PauserException.class)
+            .hasMessageContaining("Kubernetes readNamespacedDeployment API error with code 404");
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("extractLabelSelectorFromDeployment()")
+  class BuildLabelSelectorFromDeployment {
+
+    @Nested
+    @DisplayName("when deployment has valid selector")
+    class WhenDeploymentHasValidSelector {
+
+      @Test
+      @DisplayName("returns label selector string")
+      void returnsLabelSelectorString() throws ApiException, PauserException {
+        // Arrange
+        String deploymentName = "scalardb-cluster";
+
+        V1Deployment deployment =
+            mockDeploymentWithSelector(deploymentName, "v1", "scalardb-cluster");
+        deployment.getMetadata().setNamespace("default");
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act
+        String labelSelector = kubernetesClient.extractLabelSelectorFromDeployment(deployment);
+
+        // Assert
+        // The label selector format is "key = value" (with spaces)
+        assertEquals("app.kubernetes.io/app = scalardb-cluster", labelSelector);
+      }
+    }
+
+    @Nested
+    @DisplayName("when deployment has no spec")
+    class WhenDeploymentHasNoSpec {
+
+      @Test
+      @DisplayName("throws PauserException")
+      void throwsPauserException() throws ApiException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+
+        V1Deployment deployment = new V1Deployment();
+        deployment.setMetadata(new V1ObjectMeta().name(deploymentName).namespace(namespace));
+        deployment.setSpec(null);
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act & Assert
+        assertThatThrownBy(() -> kubernetesClient.extractLabelSelectorFromDeployment(deployment))
+            .isInstanceOf(PauserException.class)
+            .hasMessageContaining("does not have a spec");
+      }
+    }
+
+    @Nested
+    @DisplayName("when deployment has no selector")
+    class WhenDeploymentHasNoSelector {
+
+      @Test
+      @DisplayName("throws PauserException")
+      void throwsPauserException() throws ApiException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+
+        V1Deployment deployment = new V1Deployment();
+        deployment.setMetadata(new V1ObjectMeta().name(deploymentName).namespace(namespace));
+        deployment.setSpec(new V1DeploymentSpec().selector(null));
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act & Assert
+        assertThatThrownBy(() -> kubernetesClient.extractLabelSelectorFromDeployment(deployment))
+            .isInstanceOf(PauserException.class)
+            .hasMessageContaining("does not have a selector");
+      }
+    }
+
+    @Nested
+    @DisplayName("when deployment has empty selector")
+    class WhenDeploymentHasEmptySelector {
+
+      @Test
+      @DisplayName("throws PauserException")
+      void throwsPauserException() throws ApiException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+
+        V1Deployment deployment = new V1Deployment();
+        deployment.setMetadata(new V1ObjectMeta().name(deploymentName).namespace(namespace));
+        deployment.setSpec(
+            new V1DeploymentSpec()
+                .selector(new V1LabelSelector().matchLabels(null).matchExpressions(null)));
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act & Assert
+        assertThatThrownBy(() -> kubernetesClient.extractLabelSelectorFromDeployment(deployment))
+            .isInstanceOf(PauserException.class)
+            .hasMessageContaining("has an empty selector");
+      }
+    }
+
+    @Nested
+    @DisplayName("when deployment has invalid selector operator")
+    class WhenDeploymentHasInvalidSelectorOperator {
+
+      @Test
+      @DisplayName("throws PauserException")
+      void throwsPauserException() throws ApiException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+
+        V1Deployment deployment = new V1Deployment();
+        deployment.setMetadata(new V1ObjectMeta().name(deploymentName).namespace(namespace));
+        deployment.setSpec(
+            new V1DeploymentSpec()
+                .selector(
+                    new V1LabelSelector()
+                        .addMatchExpressionsItem(
+                            new io.kubernetes.client.openapi.models.V1LabelSelectorRequirement()
+                                .key("app")
+                                .operator("InvalidOperator")
+                                .addValuesItem("scalardb-cluster"))));
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act & Assert
+        assertThatThrownBy(() -> kubernetesClient.extractLabelSelectorFromDeployment(deployment))
+            .isInstanceOf(PauserException.class)
+            .hasMessageContaining("has an invalid selector");
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("findPodsByLabelSelector()")
+  class FindPodsByLabelSelector {
+
+    @BeforeEach
+    void setUp() throws ApiException {
+      mockCoreV1Api();
+    }
+
+    @Nested
+    @DisplayName("when pods are found")
+    class WhenPodsAreFound {
+
+      @Test
+      @DisplayName("returns list of V1Pod")
+      void returnsListOfV1Pod() throws ApiException, PauserException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+        String labelSelector = "app=scalardb-cluster";
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act
+        List<V1Pod> pods =
+            kubernetesClient.findPodsByLabelSelector(namespace, deploymentName, labelSelector);
+
+        // Assert
+        assertEquals(2, pods.size());
+      }
+    }
+
+    @Nested
+    @DisplayName("when listNamespacedPod throws ApiException")
+    class WhenListNamespacedPodThrowsApiException {
+
+      @Test
+      @DisplayName("throws PauserException")
+      void throwsPauserException() throws ApiException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+        String labelSelector = "app=scalardb-cluster";
+
+        when(coreV1Api.listNamespacedPod(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+            .thenThrow(new ApiException("", 0, null, "mock response body"));
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act & Assert
+        assertThatThrownBy(
+                () ->
+                    kubernetesClient.findPodsByLabelSelector(namespace, deploymentName, labelSelector))
+            .isInstanceOf(PauserException.class)
+            .hasMessageContaining("Kubernetes listNamespacedPod API error with code 0");
+      }
+    }
+
+    @Nested
+    @DisplayName("when no pods are found")
+    class WhenNoPodsAreFound {
+
+      @Test
+      @DisplayName("throws PauserException")
+      void throwsPauserException() throws ApiException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+        String labelSelector = "app=scalardb-cluster";
+
+        when(coreV1Api.listNamespacedPod(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+            .thenReturn(new V1PodList().items(new ArrayList<>()));
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act & Assert
+        assertThatThrownBy(
+                () ->
+                    kubernetesClient.findPodsByLabelSelector(namespace, deploymentName, labelSelector))
+            .isInstanceOf(PauserException.class)
+            .hasMessageContaining("does not have any running pods");
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("resolvePauseTargetByDeploymentName()")
+  class FindByDeploymentName {
+
+    @BeforeEach
+    void setUp() throws ApiException {
+      mockCoreV1Api();
+      mockAppsV1ApiForReadNamespacedDeployment();
+    }
+
+    @Nested
+    @DisplayName("when all components work correctly")
+    class WhenAllComponentsWorkCorrectly {
+
+      @Test
+      @DisplayName("returns PauseTarget with correct pods, deployment, and adminPort")
+      void returnsPauseTargetWithCorrectPodsDeploymentAndAdminPort()
+          throws ApiException, PauserException {
+        // Arrange
+        String namespace = "default";
+        String deploymentName = "scalardb-cluster";
+        int adminPort = 60054;
+
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act
+        PauseTarget pauseTarget =
+            kubernetesClient.resolvePauseTargetByDeploymentName(namespace, deploymentName, adminPort);
+
+        // Assert
+        assertEquals(2, pauseTarget.pods().size());
+        assertEquals(deploymentName, pauseTarget.deployment().getMetadata().getName());
+        assertEquals(adminPort, pauseTarget.adminPort());
+      }
+    }
+  }
+
   private void mockCoreV1Api() throws ApiException {
     List<V1Pod> pods =
         Arrays.asList(mockPod("pod1", "1", 0, "scalardb-cluster"), mockPod("pod2", "2", 0, "scalardb-cluster"));
@@ -602,7 +933,8 @@ public class KubernetesClientImplTest {
         .thenReturn(serviceList);
   }
 
-  private void mockAppsV1Api() throws ApiException {
+  private void mockAppsV1ApiForListNamespacedDeployment() throws ApiException {
+    // Mock listNamespacedDeployment - returns deployments without selector
     V1DeploymentList deploymentList = new V1DeploymentList();
     List<V1Deployment> deployments = Arrays.asList(mockDeployment("deployment1", "1", "scalardb-cluster"));
     deploymentList.setItems(deployments);
@@ -610,6 +942,13 @@ public class KubernetesClientImplTest {
     when(appsV1Api.listNamespacedDeployment(
             any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(deploymentList);
+  }
+
+  private void mockAppsV1ApiForReadNamespacedDeployment() throws ApiException {
+    // Mock readNamespacedDeployment - returns deployment with selector
+    V1Deployment deployment = mockDeploymentWithSelector("scalardb-cluster", "1", "scalardb");
+    deployment.getMetadata().setNamespace("default");
+    when(appsV1Api.readNamespacedDeployment(any(), any(), any())).thenReturn(deployment);
   }
 
   private V1Pod mockPod(
@@ -646,6 +985,33 @@ public class KubernetesClientImplTest {
 
     V1Deployment deployment = new V1Deployment();
     deployment.setMetadata(metadata);
+
+    return deployment;
+  }
+
+  private V1Deployment mockDeploymentWithSelector(
+      String name, String resourceVersion, String appLabelValue) {
+    Map<String, String> labels = new HashMap<>();
+    labels.put("app.kubernetes.io/app", appLabelValue);
+
+    V1ObjectMeta metadata = new V1ObjectMeta();
+    metadata.setLabels(labels);
+    metadata.setResourceVersion(resourceVersion);
+    metadata.setName(name);
+
+    // Create selector with matchLabels
+    Map<String, String> matchLabels = new HashMap<>();
+    matchLabels.put("app.kubernetes.io/app", appLabelValue);
+
+    V1LabelSelector selector = new V1LabelSelector();
+    selector.setMatchLabels(matchLabels);
+
+    V1DeploymentSpec spec = new V1DeploymentSpec();
+    spec.setSelector(selector);
+
+    V1Deployment deployment = new V1Deployment();
+    deployment.setMetadata(metadata);
+    deployment.setSpec(spec);
 
     return deployment;
   }

--- a/lib/src/test/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImplTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImplTest.java
@@ -676,6 +676,25 @@ public class KubernetesClientImplTest {
     }
 
     @Nested
+    @DisplayName("when deployment has null metadata")
+    class WhenDeploymentHasNullMetadata {
+
+      @Test
+      @DisplayName("throws PauserException")
+      void throwsPauserException() {
+        // Arrange
+        V1Deployment deployment = new V1Deployment(); // metadata null by default
+        KubernetesClientImpl kubernetesClient =
+            new KubernetesClientImpl(coreV1Api, appsV1Api);
+
+        // Act & Assert
+        assertThatThrownBy(() -> kubernetesClient.extractLabelSelectorFromDeployment(deployment))
+            .isInstanceOf(PauserException.class)
+            .hasMessageContaining("has no metadata");
+      }
+    }
+
+    @Nested
     @DisplayName("when deployment has no spec")
     class WhenDeploymentHasNoSpec {
 

--- a/lib/src/test/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImplTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImplTest.java
@@ -6,7 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.scalar.admin.kubernetes.domain.exception.PauserException;
@@ -929,6 +932,22 @@ public class KubernetesClientImplTest {
         assertEquals(2, pauseTarget.pods().size());
         assertEquals(deploymentName, pauseTarget.deployment().getMetadata().getName());
         assertEquals(adminPort, pauseTarget.adminPort());
+
+        // Verify label selector is correctly passed through to listNamespacedPod
+        // Args: namespace, pretty, allowWatchBookmarks, continue, fieldSelector, labelSelector, ...
+        verify(coreV1Api)
+            .listNamespacedPod(
+                eq(namespace),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                eq("app.kubernetes.io/app = scalardb-cluster"),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull(),
+                isNull());
       }
     }
   }
@@ -965,7 +984,7 @@ public class KubernetesClientImplTest {
 
   private void mockAppsV1ApiForReadNamespacedDeployment() throws ApiException {
     // Mock readNamespacedDeployment - returns deployment with selector
-    V1Deployment deployment = mockDeploymentWithSelector("scalardb-cluster", "1", "scalardb");
+    V1Deployment deployment = mockDeploymentWithSelector("scalardb-cluster", "1", "scalardb-cluster");
     deployment.getMetadata().setNamespace("default");
     when(appsV1Api.readNamespacedDeployment(any(), any(), any())).thenReturn(deployment);
   }

--- a/lib/src/test/java/com/scalar/admin/kubernetes/presentation/PauseControllerTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/presentation/PauseControllerTest.java
@@ -1,0 +1,355 @@
+package com.scalar.admin.kubernetes.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.scalar.admin.kubernetes.application.PauseApplicationService;
+import com.scalar.admin.kubernetes.application.dto.PauseDurationDto;
+import com.scalar.admin.kubernetes.domain.exception.PauserException;
+import com.scalar.admin.kubernetes.domain.model.pause.PauseByDeploymentNameCommand;
+import com.scalar.admin.kubernetes.domain.model.pause.PauseByHelmReleaseCommand;
+import com.scalar.admin.kubernetes.domain.model.pause.PauseCommand;
+import com.scalar.admin.kubernetes.domain.model.pause.PodDiscoveryMode;
+import com.scalar.admin.kubernetes.presentation.dto.PauseRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PauseControllerTest {
+
+  private PauseApplicationService applicationService;
+  private PauseController controller;
+
+  @BeforeEach
+  void beforeEach() {
+    applicationService = mock(PauseApplicationService.class);
+    controller = new PauseController(applicationService);
+  }
+
+  @Nested
+  @DisplayName("pause()")
+  class Pause {
+
+    @Test
+    @DisplayName("executes pause successfully with HELM_RELEASE mode")
+    void executesPauseSuccessfullyWithHelmReleaseMode() throws PauserException {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "helm-release",
+              "test-release",
+              null,
+              null,
+              5000,
+              3000L,
+              false,
+              null,
+              null);
+
+      PauseDurationDto expected = new PauseDurationDto(1000L, 6000L);
+      when(applicationService.execute(any(PauseCommand.class))).thenReturn(expected);
+
+      // Act
+      PauseDurationDto actual = controller.pause(request);
+
+      // Assert
+      assertThat(actual).isEqualTo(expected);
+      verify(applicationService).execute(any(PauseByHelmReleaseCommand.class));
+    }
+
+    @Test
+    @DisplayName("executes pause successfully with DEPLOYMENT mode")
+    void executesPauseSuccessfullyWithDeploymentMode() throws PauserException {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "deployment",
+              null,
+              "test-deployment",
+              60054,
+              5000,
+              3000L,
+              false,
+              null,
+              null);
+
+      PauseDurationDto expected = new PauseDurationDto(1000L, 6000L);
+      when(applicationService.execute(any(PauseCommand.class))).thenReturn(expected);
+
+      // Act
+      PauseDurationDto actual = controller.pause(request);
+
+      // Assert
+      assertThat(actual).isEqualTo(expected);
+      verify(applicationService).execute(any(PauseByDeploymentNameCommand.class));
+    }
+
+    @Test
+    @DisplayName("throws IllegalArgumentException when request is null")
+    void throwsIllegalArgumentExceptionWhenRequestIsNull() {
+      // Act & Assert
+      assertThatThrownBy(() -> controller.pause(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("request is required");
+    }
+
+    @Test
+    @DisplayName("throws IllegalArgumentException when podDiscoveryMode is invalid")
+    void throwsIllegalArgumentExceptionWhenPodDiscoveryModeIsInvalid() {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "invalid-mode",
+              "test-release",
+              null,
+              null,
+              5000,
+              3000L,
+              false,
+              null,
+              null);
+
+      // Act & Assert
+      assertThatThrownBy(() -> controller.pause(request))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Invalid podDiscoveryMode");
+    }
+  }
+
+  @Nested
+  @DisplayName("createCommand()")
+  class CreateCommand {
+
+    @Test
+    @DisplayName("creates PauseByHelmReleaseCommand when mode is HELM_RELEASE")
+    void createsPauseByHelmReleaseCommandWhenModeIsHelmRelease() {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "helm-release",
+              "test-release",
+              null,
+              null,
+              5000,
+              3000L,
+              false,
+              null,
+              null);
+
+      // Act
+      PauseCommand command = controller.createCommand(request, PodDiscoveryMode.HELM_RELEASE);
+
+      // Assert
+      assertThat(command).isInstanceOf(PauseByHelmReleaseCommand.class);
+    }
+
+    @Test
+    @DisplayName("creates PauseByDeploymentNameCommand when mode is DEPLOYMENT")
+    void createsPauseByDeploymentNameCommandWhenModeIsDeployment() {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "deployment",
+              null,
+              "test-deployment",
+              60054,
+              5000,
+              3000L,
+              false,
+              null,
+              null);
+
+      // Act
+      PauseCommand command = controller.createCommand(request, PodDiscoveryMode.DEPLOYMENT);
+
+      // Assert
+      assertThat(command).isInstanceOf(PauseByDeploymentNameCommand.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("createHelmReleaseCommand()")
+  class CreateHelmReleaseCommand {
+
+    @Test
+    @DisplayName("creates command without TLS when tlsEnabled is false")
+    void createsCommandWithoutTlsWhenTlsEnabledIsFalse() {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "helm-release",
+              "test-release",
+              null,
+              null,
+              5000,
+              3000L,
+              false,
+              null,
+              null);
+
+      // Act
+      PauseByHelmReleaseCommand command = controller.createHelmReleaseCommand(request);
+
+      // Assert
+      assertThat(command.namespace()).isEqualTo("test-ns");
+      assertThat(command.helmReleaseName()).isEqualTo("test-release");
+      assertThat(command.pauseDuration()).isEqualTo(5000);
+      assertThat(command.maxPauseWaitTime()).isEqualTo(3000L);
+      assertThat(command.tlsConfig()).isNull();
+    }
+
+    @Test
+    @DisplayName("creates command with TLS when tlsEnabled is true")
+    void createsCommandWithTlsWhenTlsEnabledIsTrue() {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "helm-release",
+              "test-release",
+              null,
+              null,
+              5000,
+              3000L,
+              true,
+              "dummyCert",
+              "dummyAuthority");
+
+      // Act
+      PauseByHelmReleaseCommand command = controller.createHelmReleaseCommand(request);
+
+      // Assert
+      assertThat(command.namespace()).isEqualTo("test-ns");
+      assertThat(command.helmReleaseName()).isEqualTo("test-release");
+      assertThat(command.pauseDuration()).isEqualTo(5000);
+      assertThat(command.maxPauseWaitTime()).isEqualTo(3000L);
+      assertThat(command.tlsConfig()).isNotNull();
+      assertThat(command.tlsConfig().caRootCert()).isEqualTo("dummyCert");
+      assertThat(command.tlsConfig().overrideAuthority()).isEqualTo("dummyAuthority");
+    }
+
+    @Test
+    @DisplayName("creates command with null maxPauseWaitTime when not specified")
+    void createsCommandWithNullMaxPauseWaitTimeWhenNotSpecified() {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "helm-release",
+              "test-release",
+              null,
+              null,
+              5000,
+              null,
+              false,
+              null,
+              null);
+
+      // Act
+      PauseByHelmReleaseCommand command = controller.createHelmReleaseCommand(request);
+
+      // Assert
+      assertThat(command.maxPauseWaitTime()).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("createDeploymentCommand()")
+  class CreateDeploymentCommand {
+
+    @Test
+    @DisplayName("creates command without TLS when tlsEnabled is false")
+    void createsCommandWithoutTlsWhenTlsEnabledIsFalse() {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "deployment",
+              null,
+              "test-deployment",
+              60054,
+              5000,
+              3000L,
+              false,
+              null,
+              null);
+
+      // Act
+      PauseByDeploymentNameCommand command = controller.createDeploymentCommand(request);
+
+      // Assert
+      assertThat(command.namespace()).isEqualTo("test-ns");
+      assertThat(command.deploymentName()).isEqualTo("test-deployment");
+      assertThat(command.adminPort()).isEqualTo(60054);
+      assertThat(command.pauseDuration()).isEqualTo(5000);
+      assertThat(command.maxPauseWaitTime()).isEqualTo(3000L);
+      assertThat(command.tlsConfig()).isNull();
+    }
+
+    @Test
+    @DisplayName("creates command with TLS when tlsEnabled is true")
+    void createsCommandWithTlsWhenTlsEnabledIsTrue() {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "deployment",
+              null,
+              "test-deployment",
+              60054,
+              5000,
+              3000L,
+              true,
+              "dummyCert",
+              "dummyAuthority");
+
+      // Act
+      PauseByDeploymentNameCommand command = controller.createDeploymentCommand(request);
+
+      // Assert
+      assertThat(command.namespace()).isEqualTo("test-ns");
+      assertThat(command.deploymentName()).isEqualTo("test-deployment");
+      assertThat(command.adminPort()).isEqualTo(60054);
+      assertThat(command.pauseDuration()).isEqualTo(5000);
+      assertThat(command.maxPauseWaitTime()).isEqualTo(3000L);
+      assertThat(command.tlsConfig()).isNotNull();
+      assertThat(command.tlsConfig().caRootCert()).isEqualTo("dummyCert");
+      assertThat(command.tlsConfig().overrideAuthority()).isEqualTo("dummyAuthority");
+    }
+
+    @Test
+    @DisplayName("creates command with null maxPauseWaitTime when not specified")
+    void createsCommandWithNullMaxPauseWaitTimeWhenNotSpecified() {
+      // Arrange
+      PauseRequest request =
+          new PauseRequest(
+              "test-ns",
+              "deployment",
+              null,
+              "test-deployment",
+              60054,
+              5000,
+              null,
+              false,
+              null,
+              null);
+
+      // Act
+      PauseByDeploymentNameCommand command = controller.createDeploymentCommand(request);
+
+      // Assert
+      assertThat(command.maxPauseWaitTime()).isNull();
+    }
+  }
+}

--- a/lib/src/test/java/com/scalar/admin/kubernetes/presentation/dto/PauseRequestTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/presentation/dto/PauseRequestTest.java
@@ -186,34 +186,6 @@ class PauseRequestTest {
     }
 
     @Nested
-    @DisplayName("when pauseDuration is invalid")
-    class WhenPauseDurationIsInvalid {
-
-      @ParameterizedTest
-      @ValueSource(ints = {0, -1, -100, -1000})
-      @DisplayName("throws IllegalArgumentException")
-      void throwsIllegalArgumentException(int invalidPauseDuration) {
-        // Arrange & Act & Assert
-        assertThatThrownBy(
-                () ->
-                    new PauseRequest(
-                        "default",
-                        "helm-release",
-                        "my-release",
-                        null,
-                        null,
-                        invalidPauseDuration,
-                        null,
-                        false,
-                        null,
-                        null))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage(
-                "pauseDuration must be greater than 0, but was: " + invalidPauseDuration);
-      }
-    }
-
-    @Nested
     @DisplayName("when tlsEnabled is true but caRootCert is missing")
     class WhenTlsEnabledButCaRootCertIsMissing {
 

--- a/lib/src/test/java/com/scalar/admin/kubernetes/presentation/dto/PauseRequestTest.java
+++ b/lib/src/test/java/com/scalar/admin/kubernetes/presentation/dto/PauseRequestTest.java
@@ -1,6 +1,7 @@
 package com.scalar.admin.kubernetes.presentation.dto;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,16 +21,29 @@ class PauseRequestTest {
     class WhenGivenValidParameters {
 
       @Test
-      @DisplayName("creates PauseRequest successfully")
-      void createsPauseRequestSuccessfully() {
+      @DisplayName("creates PauseRequest with helm-release mode")
+      void createsPauseRequestWithHelmReleaseMode() {
         // Arrange & Act
         PauseRequest request =
-            new PauseRequest("default", "my-release", 5000, 30000L, false, null, null);
+            new PauseRequest(
+                "default",
+                "helm-release",
+                "my-release",
+                null,
+                null,
+                5000,
+                30000L,
+                false,
+                null,
+                null);
 
         // Assert
         assertThat(request).isNotNull();
         assertThat(request.namespace()).isEqualTo("default");
+        assertThat(request.podDiscoveryMode()).isEqualTo("helm-release");
         assertThat(request.helmReleaseName()).isEqualTo("my-release");
+        assertThat(request.deploymentName()).isNull();
+        assertThat(request.adminPort()).isNull();
         assertThat(request.pauseDuration()).isEqualTo(5000);
         assertThat(request.maxPauseWaitTime()).isEqualTo(30000L);
         assertThat(request.tlsEnabled()).isFalse();
@@ -38,12 +52,48 @@ class PauseRequestTest {
       }
 
       @Test
+      @DisplayName("creates PauseRequest with deployment mode")
+      void createsPauseRequestWithDeploymentMode() {
+        // Arrange & Act
+        PauseRequest request =
+            new PauseRequest(
+                "default",
+                "deployment",
+                null,
+                "my-deployment",
+                60054,
+                5000,
+                null,
+                false,
+                null,
+                null);
+
+        // Assert
+        assertThat(request).isNotNull();
+        assertThat(request.namespace()).isEqualTo("default");
+        assertThat(request.podDiscoveryMode()).isEqualTo("deployment");
+        assertThat(request.helmReleaseName()).isNull();
+        assertThat(request.deploymentName()).isEqualTo("my-deployment");
+        assertThat(request.adminPort()).isEqualTo(60054);
+        assertThat(request.pauseDuration()).isEqualTo(5000);
+      }
+
+      @Test
       @DisplayName("creates PauseRequest with TLS enabled")
       void createsPauseRequestWithTls() {
         // Arrange & Act
         PauseRequest request =
             new PauseRequest(
-                "default", "my-release", 5000, null, true, "cert-content", "authority");
+                "default",
+                "helm-release",
+                "my-release",
+                null,
+                null,
+                5000,
+                null,
+                true,
+                "cert-content",
+                "authority");
 
         // Assert
         assertThat(request).isNotNull();
@@ -57,7 +107,8 @@ class PauseRequestTest {
       void createsPauseRequestWithNullMaxPauseWaitTime() {
         // Arrange & Act
         PauseRequest request =
-            new PauseRequest("default", "my-release", 5000, null, false, null, null);
+            new PauseRequest(
+                "default", "helm-release", "my-release", null, null, 5000, null, false, null, null);
 
         // Assert
         assertThat(request).isNotNull();
@@ -68,7 +119,9 @@ class PauseRequestTest {
       @DisplayName("creates PauseRequest with minimal pause duration (1ms)")
       void createsPauseRequestWithMinimalPauseDuration() {
         // Arrange & Act
-        PauseRequest request = new PauseRequest("default", "my-release", 1, null, false, null, null);
+        PauseRequest request =
+            new PauseRequest(
+                "default", "helm-release", "my-release", null, null, 1, null, false, null, null);
 
         // Assert
         assertThat(request).isNotNull();
@@ -89,28 +142,46 @@ class PauseRequestTest {
         assertThatThrownBy(
                 () ->
                     new PauseRequest(
-                        invalidNamespace, "my-release", 5000, null, false, null, null))
+                        invalidNamespace,
+                        "helm-release",
+                        "my-release",
+                        null,
+                        null,
+                        5000,
+                        null,
+                        false,
+                        null,
+                        null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("namespace is required");
       }
     }
 
     @Nested
-    @DisplayName("when helmReleaseName is invalid")
-    class WhenHelmReleaseNameIsInvalid {
+    @DisplayName("when podDiscoveryMode is invalid")
+    class WhenPodDiscoveryModeIsInvalid {
 
       @ParameterizedTest
       @NullAndEmptySource
       @ValueSource(strings = {"  ", "   "})
       @DisplayName("throws IllegalArgumentException")
-      void throwsIllegalArgumentException(String invalidHelmReleaseName) {
+      void throwsIllegalArgumentException(String invalidPodDiscoveryMode) {
         // Arrange & Act & Assert
         assertThatThrownBy(
                 () ->
                     new PauseRequest(
-                        "default", invalidHelmReleaseName, 5000, null, false, null, null))
+                        "default",
+                        invalidPodDiscoveryMode,
+                        "my-release",
+                        null,
+                        null,
+                        5000,
+                        null,
+                        false,
+                        null,
+                        null))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("helmReleaseName is required");
+            .hasMessage("podDiscoveryMode is required");
       }
     }
 
@@ -126,7 +197,16 @@ class PauseRequestTest {
         assertThatThrownBy(
                 () ->
                     new PauseRequest(
-                        "default", "my-release", invalidPauseDuration, null, false, null, null))
+                        "default",
+                        "helm-release",
+                        "my-release",
+                        null,
+                        null,
+                        invalidPauseDuration,
+                        null,
+                        false,
+                        null,
+                        null))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage(
                 "pauseDuration must be greater than 0, but was: " + invalidPauseDuration);
@@ -146,7 +226,7 @@ class PauseRequestTest {
         assertThatThrownBy(
                 () ->
                     new PauseRequest(
-                        "default", "my-release", 5000, null, true, invalidCaRootCert, "authority"))
+                        "default", "helm-release", "my-release", null, null, 5000, null, true, invalidCaRootCert, "authority"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("caRootCert is required when tlsEnabled is true");
       }
@@ -166,7 +246,10 @@ class PauseRequestTest {
                 () ->
                     new PauseRequest(
                         "default",
+                        "helm-release",
                         "my-release",
+                        null,
+                        null,
                         5000,
                         null,
                         true,


### PR DESCRIPTION
## Description

This PR adds support for pausing Scalar products by **Kubernetes Deployment name** in addition to the existing Helm release name approach. This feature is built on top of the Onion Architecture refactoring completed in #46.

Currently, `scalar-admin-for-kubernetes` only supports pausing Scalar products by specifying a Helm release name (`--release-name`). This creates limitations in the following scenarios:

1. **Non-Helm deployments**: Deployments created with `kubectl apply` or other tools cannot be paused
2. **Helm dependency**: Users must have Helm installed and access to release metadata
3. **CI/CD environments**: Automated environments may have direct access to deployment names but not Helm release information

By introducing a deployment mode, this tool becomes more versatile and easier to integrate into various operational workflows, removing the hard dependency on Helm for pause operations.

## Related issues and/or PRs

- Depends on #46 (Onion Architecture refactoring)

## Changes made

### 1. New CLI Options

Added three new command-line options to support deployment mode:

- `--pod-discovery-mode` (default: `helm-release` for **backward compatibility**)
  - Values: `helm-release` | `deployment`
  - Specifies how to discover target pods

- `--deployment-name` (required when `--pod-discovery-mode=deployment`)
  - The name of the Kubernetes Deployment for the Scalar product

- `--admin-port` (required when `--pod-discovery-mode=deployment`)
  - The port number of the admin interface (e.g.,60053)

#### Usage Examples

**Existing Helm Release Mode (unchanged):**
```bash
java -jar scalar-admin-for-kubernetes-cli.jar \
  --release-name scalardb-cluster \
  --namespace default \
  --pause-duration 5000
```

**New Helm Release Mode:**
```bash
java -jar scalar-admin-for-kubernetes-cli.jar \
  --pod-discovery-mode helm-release \
  --release-name scalardb-cluster \
  --namespace default \
  --pause-duration 5000
```

**New Deployment Mode:**
```bash
java -jar scalar-admin-for-kubernetes-cli.jar \
  --pod-discovery-mode deployment \
  --deployment-name scalardb-cluster-node \
  --admin-port 60053 \
  --namespace default \
  --pause-duration 5000
```

### 2. Architecture Implementation (7 Phases)

Following Onion Architecture principles:

**Phase 1 - Domain Layer**: Introduced `PodDiscoveryMode` enum
- `lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PodDiscoveryMode.java`
- Core domain concept with validation logic

**Phase 2 - Presentation Layer**: Added CLI option parsing
- `cli/src/main/java/com/scalar/admin/kubernetes/Cli.java`
- Case-insensitive enum value parsing

**Phase 3 - Domain Layer**: Created `PauseByDeploymentNameCommand`
- `lib/src/main/java/com/scalar/admin/kubernetes/domain/model/pause/PauseByDeploymentNameCommand.java`
- New domain command implementing `PauseCommand` interface

**Phase 4 - Infrastructure Layer**: Implemented deployment-based pod discovery
- `lib/src/main/java/com/scalar/admin/kubernetes/domain/client/KubernetesClient.java`
- `lib/src/main/java/com/scalar/admin/kubernetes/infrastructure/client/KubernetesClientImpl.java`
- Added `resolvePauseTargetByDeploymentName()` method using Kubernetes label selectors

**Phase 5 - Application Layer**: Updated `PauseApplicationService`
- `lib/src/main/java/com/scalar/admin/kubernetes/application/PauseApplicationService.java`
- Pattern matching on command type to route to appropriate method

**Phase 6 - Presentation Layer**: Updated `PauseController`
- `lib/src/main/java/com/scalar/admin/kubernetes/presentation/PauseController.java`
- Creates appropriate command based on `PodDiscoveryMode`

**Phase 7 - CLI Output**: Updated `Result` class
- `cli/src/main/java/com/scalar/admin/kubernetes/Result.java`
- Supports both modes in JSON output with `pod_discovery_mode`, `helm_release_name`, and `deployment_name` fields

### 3. E2E Testing

**Enhanced existing E2E test** (`.github/workflows/e2e-helm-release.yml`):
- Renamed from `e2e.yml` to `e2e-helm-release.yml` for clarity
- Added matrix dimension to test both implicit and explicit pod discovery modes:
  - Without `--pod-discovery-mode` (backward compatibility)
  - With `--pod-discovery-mode helm-release` (explicit mode)

**Added new E2E test** (`.github/workflows/e2e-deployment.yml`):
- Tests deployment mode with ScalarDB Cluster, ScalarDL Ledger, and ScalarDL Auditor
- Uses matrix strategy for multiple products
- Dynamically discovers deployment names using Kubernetes label selectors
- Validates pause/unpause with correct admin ports:
  - ScalarDB Cluster: port 60053
  - ScalarDL Ledger: port 50053
  - ScalarDL Auditor: port 40053

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

### Manual E2E Testing
Assuming ScalarDB Cluster is already deployed on a Kubernetes cluster, set up the test client and run the tool as follows:

1. Deploy the client pod

```sh
kubectl apply -f .github/manifests/client-pod.yaml
kubectl wait --for=condition=Available deployment/foo-scalardb-cluster-node --timeout 30s
kubectl wait --for=condition=Ready pod/java21 --timeout 30s
```

2. Build the Shadow JAR and copy it to the client pod

```sh
./gradlew shadowJar

VERSION=$(./gradlew :cli:properties -q | grep "version:" | awk '{print $2}')

kubectl cp cli/build/libs/scalar-admin-for-kubernetes-cli-${VERSION}.jar java21:/tmp
```

3. Run the tool

Deployment mode (new feature in this PR):
```sh
kubectl exec -it java21 -- java -jar /tmp/scalar-admin-for-kubernetes-cli-${VERSION}.jar \
  --pod-discovery-mode deployment \
  --deployment-name scalardb-cluster-node \
  --admin-port 60053 \
  --namespace default
```

Helm release mode (existing feature, regression check):
```sh
kubectl exec -it java21 -- java -jar /tmp/scalar-admin-for-kubernetes-cli-${VERSION}.jar \
  --release-name scalardb-cluster \
  --namespace default
```

4. Expected output

Deployment mode:
```json
{
  "namespace": "default",
  "timezone": "Etc/UTC",
  "pod_discovery_mode": "deployment",
  "deployment_name": "scalardb-cluster-node",
  "pause_start_timestamp_ms": 1782234096290,
  "pause_end_timestamp_ms": 1782234101290,
  "pause_start_date_time": "2026-06-23T17:01:36.290",
  "pause_end_date_time": "2026-06-23T17:01:41.290"
}
```

Helm release mode:
```json
{
  "namespace": "default",
  "timezone": "Etc/UTC",
  "pod_discovery_mode": "helm-release",
  "helm_release_name": "scalardb-cluster",
  "pause_start_timestamp_ms": 1782234299793,
  "pause_end_timestamp_ms": 1782234304793,
  "pause_start_date_time": "2026-06-23T17:04:59.793",
  "pause_end_date_time": "2026-06-23T17:05:04.793"
}
```

Helm release mode with explicit --pod-discovery-mode:
```json
{
  "namespace": "default",
  "timezone": "Etc/UTC",
  "pod_discovery_mode": "helm-release",
  "helm_release_name": "scalardb-cluster",
  "pause_start_timestamp_ms": 1782234858523,
  "pause_end_timestamp_ms": 1782234863523,
  "pause_start_date_time": "2026-06-23T17:14:18.523",
  "pause_end_date_time": "2026-06-23T17:14:23.523"
}
```

5. clean up
```sh
  kubectl delete -f .github/manifests/client-pod.yaml
```