### PR TITLE
Migrate Maven publishing from OSSRH to Maven Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,12 @@ jobs:
 
       - name: Upload the package to Maven Central Repository
         run: |
-          echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 -d > /tmp/secring.gpg
           ./gradlew publish \
             -PprojVersion="${{ steps.version.outputs.version }}" \
-            -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}" \
-            -P'signing.password'="${{ secrets.SIGNING_PASSWORD }}" \
-            -Psigning.secretKeyRingFile='/tmp/secring.gpg' \
-            -PossrhUsername="${{ secrets.OSSRH_USERNAMAE }}" \
-            -PossrhPassword="${{ secrets.OSSRH_PASSWORD }}"
+            -PsigningKey="${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}" \
+            -PsigningPassword="${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}" \
+            -PossrhUsername="${{ secrets.MAVEN_CENTRAL_USERNAME }}" \
+            -PossrhPassword="${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
 
       - name: Build the shadow Jar
         run: ./gradlew shadowJar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,14 @@ jobs:
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Upload the package to Maven Central Repository
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
           ./gradlew publish \
-            -PprojVersion="${{ steps.version.outputs.version }}" \
-            -PsigningKey="${{ secrets.MAVEN_CENTRAL_GPG_SECRET_KEY }}" \
-            -PsigningPassword="${{ secrets.MAVEN_CENTRAL_GPG_PASSPHRASE }}" \
-            -PossrhUsername="${{ secrets.MAVEN_CENTRAL_USERNAME }}" \
-            -PossrhPassword="${{ secrets.MAVEN_CENTRAL_PASSWORD }}"
+            -PprojVersion="${{ steps.version.outputs.version }}"
 
       - name: Build the shadow Jar
         run: ./gradlew shadowJar

--- a/lib/archive.gradle
+++ b/lib/archive.gradle
@@ -51,7 +51,7 @@ signing {
     def signingKey = findProperty("signingKey")
     def signingPassword = findProperty("signingPassword")
 
-    if (signingKey != null && signingPassword != null) {
+    if (signingKey && signingPassword) {
         useInMemoryPgpKeys(signingKey, signingPassword)
         sign publishing.publications.mavenJava
     }

--- a/lib/archive.gradle
+++ b/lib/archive.gradle
@@ -38,17 +38,21 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots"
+            def releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = "${ossrhUsername}"
-                password = "${ossrhPassword}"
-            }
+            name = "ossrh"
+            credentials(PasswordCredentials)
         }
     }
 }
 
 signing {
-    sign publishing.publications.mavenJava
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.mavenJava
+    }
 }


### PR DESCRIPTION
## Description

The legacy `oss.sonatype.org` endpoints have been deprecated and now return 405 errors. This migrates to the new Central Portal URLs and switches from file-based GPG signing to in-memory PGP keys.

## Related issues and/or PRs

- scalar-labs/scalardb#2849 

## Changes made

1. Updated repository URLs for Maven Central Portal (`lib/archive.gradle`)
  - Releases: https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/
  - Snapshots: https://central.sonatype.com/repository/maven-snapshots/
2. Switched to in-memory GPG signing (`lib/archive.gradle`)
  - Replaced file-based signing (`secring.gpg`) with `useInMemoryPgpKeys()`
  - Signing is now conditional (ie only enabled when signing properties are provided)
3. Updated CI workflow secrets (`.github/workflows/release.yml`)
  - `SIGNING_KEY_ID`, `SIGNING_PASSWORD`, `SIGNING_SECRET_KEY_RING` → `MAVEN_CENTRAL_GPG_SECRET_KEY`, `MAVEN_CENTRAL_GPG_PASSPHRASE`
  - `OSSRH_USERNAMAE`, `OSSRH_PASSWORD` → `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`
  - Removed base64 keyring file generation step
  - Pass secrets via `ORG_GRADLE_PROJECT_*` environment variables instead of `-P` command-line arguments to  avoid exposing them in process args

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

- This project uses org-level secrets (`MAVEN_CENTRAL_*`) which are already available.
- Unlike ScalarDB which adopted JReleaser, this project only has a single publishable module (`lib`), so the simpler URL + signing migration approach is sufficient.

